### PR TITLE
fix: Change the HTTP response for uploading an existing version to 403

### DIFF
--- a/src/vdoc/exceptions/__init__.py
+++ b/src/vdoc/exceptions/__init__.py
@@ -58,7 +58,7 @@ class ProjectVersionAlreadyExists(VDocException):
 
     def __init__(self, name: str, version: Version | str) -> None:  # noqa: D107
         super().__init__(
-            status_code=status.HTTP_404_NOT_FOUND, detail=f"Version '{version}' of project '{name}' already exists."
+            status_code=status.HTTP_403_FORBIDDEN, detail=f"Version '{version}' of project '{name}' already exists."
         )
 
 

--- a/tests/unit/api/routes/test_project_routes.py
+++ b/tests/unit/api/routes/test_project_routes.py
@@ -136,3 +136,31 @@ def test_upload_project_version_route_no_index_html(
             status_code=400,
             message="The uploaded file is invalid: The archive doesn't contain an index.html file.",
         )
+
+
+def test_upload_existing_project_version_route(
+    dummy_projects_dir: Path, authenticated_api: TestClient, example_docs_zip: Path
+) -> None:
+    version: str = "4.0.0"
+    project_name: str = "dummy-project-01"
+    project_version_dir = dummy_projects_dir / project_name / version
+    assert not project_version_dir.is_dir()
+    response = authenticated_api.post(
+        f"/api/projects/{project_name}/versions/{version}",
+        files={"file": (example_docs_zip.name, example_docs_zip.read_bytes(), "application/zip")},
+    )
+    assert_api_response(
+        response=response,
+        status_code=201,
+        message=f"Version '{version}' of project '{project_name}' uploaded successfully.",
+    )
+    assert (project_version_dir).is_dir()
+    response = authenticated_api.post(
+        f"/api/projects/{project_name}/versions/{version}",
+        files={"file": (example_docs_zip.name, example_docs_zip.read_bytes(), "application/zip")},
+    )
+    assert_api_response(
+        response=response,
+        status_code=403,
+        message=f"Version '{version}' of project '{project_name}' already exists.",
+    )


### PR DESCRIPTION
404 does not seem like the correct error code for trying to upload a duplicate version. Also adds a test for this behaviour/route