### PR TITLE
docs: Add more config documentation to the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ All configuration environment variables are prefixed with ``VDOC_``:
      - Explanation
      - Default
    * - ``VDOC_DOCS_DIR``
-     - The directory to which all project documentations will be uploaded to.
+     - The directory to which all project documentations will be uploaded.
      - ``/srv/vdoc/docs/``
    * - ``VDOC_API_USERNAME``
      - The username required for uploading documentations via the API.

--- a/README.rst
+++ b/README.rst
@@ -85,3 +85,15 @@ All configuration environment variables are prefixed with ``VDOC_``:
    * - ``VDOC_DOCS_DIR``
      - The directory to which all project documentations will be uploaded to.
      - ``/srv/vdoc/docs/``
+   * - ``VDOC_API_USERNAME``
+     - The username required for uploading documentations via the API.
+     - ``admin``
+   * - ``VDOC_API_PASSWORD``
+     - The password required for uploading documentations via the API.
+     - ``admin``
+   * - ``VDOC_BIND_ADDRESS``
+     - The application bind address.
+     - ``0.0.0.0``
+   * - ``VDOC_BIND_ADDRESS``
+     - The application bind port.
+     - ``8080``


### PR DESCRIPTION
These new options were missing in the configuration section.