### PR TITLE
test: Fix flaky iframe content checks

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
     viewport: { width: 1280, height: 720 },
     actionTimeout: 0,
     baseURL: 'http://localhost:3000',
-    trace: 'on-first-retry',
+    trace: 'on',
   },
   webServer: {
     command: 'npm run dev -- --port 3000',

--- a/tests/ui/testIndexPage.spec.ts
+++ b/tests/ui/testIndexPage.spec.ts
@@ -22,6 +22,8 @@ test('Test navigation index to documentation to version overview', async ({ page
   await expect(page).toHaveURL(/.*example-project-01\/latest/)
 
   // Ensure documentation is rendered in the iframe
+  await expect(docIframe).toBeAttached()
+  await expect(docIframe.contentFrame().locator('html')).toBeAttached()
   await expect(docIframe.contentFrame().locator('html')).toContainText(expectedDocumentationContent)
 
   // Test the version dropdown. The latest version is 3.2.0. There must be 5 options including a link to more
@@ -47,6 +49,7 @@ test('Test navigation index to documentation to version overview', async ({ page
   // Make sure that all variables have updated correctly
   await expect(page).toHaveURL(/.*example-project-01\/1.0.0/)
   await expect(latestVersionWarningBanner).toBeVisible()
+  await expect(docIframe.contentFrame().locator('html')).toBeAttached()
   await expect(docIframe.contentFrame().locator('html')).toContainText(expectedDocumentationContent)
   await expect(versionDropdown).toContainText('1.0.0')
 })

--- a/tests/ui/testLinkSubstitution.spec.ts
+++ b/tests/ui/testLinkSubstitution.spec.ts
@@ -8,6 +8,8 @@ test('Test link substitution', async ({ page }) => {
 
   // Expect the documentation iframe to display the mocked documentation page
   await page.goto('/example-project-01/latest')
+  await expect(docIframe).toBeAttached()
+  await expect(docIframe.contentFrame().locator('html')).toBeAttached()
   await expect(docIframe.contentFrame().locator('html')).toContainText(expectedDocumentationContent)
 
   // Ensure that all links have been substituted correctly

--- a/tests/ui/testLinkSubstitution.spec.ts
+++ b/tests/ui/testLinkSubstitution.spec.ts
@@ -2,13 +2,14 @@ import { expect } from '@playwright/test'
 import test from './base'
 
 test('Test link substitution', async ({ page }) => {
-  const docIframe = page.getByTestId('docIframe')
   const expectedDocumentationContent = 'Hello, this is a mocked documentation component.'
   const basePath = 'http://localhost:3000'
 
   // Expect the documentation iframe to display the mocked documentation page
   await page.goto('/example-project-01/latest')
+  const docIframe = page.getByTestId('docIframe')
   await expect(docIframe).toBeAttached()
+  await expect(docIframe).toBeVisible()
   await expect(docIframe.contentFrame().locator('html')).toBeAttached()
   await expect(docIframe.contentFrame().locator('html')).toContainText(expectedDocumentationContent)
 


### PR DESCRIPTION
Currently, the test is flaky

```
Error: Timed out 5000ms waiting for expect(locator).toBeAttached()
    Locator: getByTestId('docIframe').contentFrame().locator('html')
    Expected: attached
    Received: <element(s) not found>

1 flaky
    [chromium] › tests/ui/testLinkSubstitution.spec.ts:4:1 › Test link substitution
2 passed (11.4s)
```
