### PR TITLE
ci: Group dependabot updates by dev/prod dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"


### PR DESCRIPTION
According to https://docs.github.com/de/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates

This should reduce the number of PRs.