### PR TITLE
fix: Fix flaky playwright tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, devices } from '@playwright/test'
 export default defineConfig({
   testDir: 'tests/ui',
   timeout: 30000,
-  retries: 1,
+  retries: 0,
   fullyParallel: true,
   reporter: [['html', { open: 'never' }]],
   projects: [

--- a/tests/ui/base.ts
+++ b/tests/ui/base.ts
@@ -4,7 +4,7 @@ import { ColorMode } from '../../src/ui/interfacesAndTypes/ColorModes'
 import fs from 'fs'
 import path from 'path'
 
-const mockAPIRequests = async (page: Page) => {
+export const mockAPIRequests = async (page: Page) => {
   const routes = [
     {
       pattern: '*/**/static/projects/*/*/',
@@ -45,10 +45,6 @@ const mockAPIRequests = async (page: Page) => {
     await page.route(pattern, (route) => route.fulfill(response))
   }
 }
-
-test.beforeEach(async ({ page }) => {
-  await mockAPIRequests(page)
-})
 
 interface ColorModeProps {
   appBarColor: string

--- a/tests/ui/base.ts
+++ b/tests/ui/base.ts
@@ -1,8 +1,27 @@
-import { test } from '@playwright/test'
-import { Page } from '@playwright/test'
-import { ColorMode } from '../../src/ui/interfacesAndTypes/ColorModes'
+import test from '@playwright/test'
+import type {
+  TestType,
+  PlaywrightTestArgs,
+  PlaywrightTestOptions,
+  PlaywrightWorkerArgs,
+  PlaywrightWorkerOptions,
+} from '@playwright/test'
+import type { Page } from '@playwright/test'
+import type { ColorMode } from '../../src/ui/interfacesAndTypes/ColorModes'
 import fs from 'fs'
 import path from 'path'
+
+export const prepareTestSuite = async (
+  test: TestType<PlaywrightTestArgs & PlaywrightTestOptions, PlaywrightWorkerArgs & PlaywrightWorkerOptions>
+) => {
+  test.beforeEach(async ({ page }) => {
+    await mockAPIRequests(page)
+  })
+
+  test.afterEach(async ({ page }) => {
+    await page.unrouteAll()
+  })
+}
 
 export const mockAPIRequests = async (page: Page) => {
   const routes = [

--- a/tests/ui/helpers.ts
+++ b/tests/ui/helpers.ts
@@ -1,4 +1,4 @@
-import { Page, expect } from '@playwright/test'
+import { Locator, Page, expect } from '@playwright/test'
 import { ColorMode, EffectiveColorMode } from '../../src/ui/interfacesAndTypes/ColorModes'
 import testIDs from '../../src/ui/interfacesAndTypes/testIDs'
 import { themes } from './base'
@@ -46,6 +46,7 @@ export const closeSettingsSidebar = async (page: Page) => {
 
 /**
  * Ensures that the currently selected color mode in the settings sidebar is ``mode``.
+ *
  * @param page The playwright page object.
  * @param mode The color mode button that should be selected.
  */
@@ -66,7 +67,8 @@ export const assertCurrentColorModeButton = async (page: Page, mode: ColorMode) 
 }
 
 /**
- * Switches the color mode th ``mode``.
+ * Switches the color mode to ``mode``.
+ *
  * @param page The playwright page object.
  * @param mode he color mode that should be applied.
  */
@@ -74,4 +76,28 @@ export const switchColorMode = async (page: Page, mode: ColorMode) => {
   await openSettingsSidebar(page)
   await page.getByTestId(testIDs.sidebar.settings.toggleColorModes.buttons[mode]).click()
   await assertCurrentColorModeButton(page, mode)
+}
+
+/**
+ * Opens a documentation and waits for the iframe to be fully loaded.
+ *
+ * @param page The playwright page object.
+ * @param name The project name.
+ * @param version The project version.
+ * @returns The iframe locator.
+ */
+export const openProjectDocumentation = async (page: Page, name: string, version: string): Promise<Locator> => {
+  const docIframe = page.getByTestId(testIDs.project.documentation.documentationIframe)
+
+  await page.goto(`/${name}/${version}`)
+
+  await expect(docIframe).toBeVisible({ timeout: 10000 })
+
+  await docIframe.waitFor({ state: 'attached' })
+  const iframeDocument = docIframe.contentFrame()
+  expect(iframeDocument).not.toBeNull()
+
+  await expect(iframeDocument.locator('html')).toBeVisible({ timeout: 10000 })
+
+  return iframeDocument.locator('html')
 }

--- a/tests/ui/helpers.ts
+++ b/tests/ui/helpers.ts
@@ -1,5 +1,6 @@
-import { Locator, Page, expect } from '@playwright/test'
-import { ColorMode, EffectiveColorMode } from '../../src/ui/interfacesAndTypes/ColorModes'
+import { expect } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
+import type { ColorMode, EffectiveColorMode } from '../../src/ui/interfacesAndTypes/ColorModes'
 import testIDs from '../../src/ui/interfacesAndTypes/testIDs'
 import { themes } from './base'
 

--- a/tests/ui/testIndexPage.spec.ts
+++ b/tests/ui/testIndexPage.spec.ts
@@ -1,14 +1,8 @@
 import { expect } from '@playwright/test'
-import test, { mockAPIRequests } from './base'
+import test, { prepareTestSuite } from './base'
 import testIDs from '../../src/ui/interfacesAndTypes/testIDs'
 
-test.beforeEach(async ({ page }) => {
-  await mockAPIRequests(page)
-})
-
-test.afterEach(async ({ page }) => {
-  await page.unrouteAll()
-})
+await prepareTestSuite(test)
 
 test('Test navigation index to documentation to version overview', async ({ page }) => {
   await page.goto('/')

--- a/tests/ui/testIndexPage.spec.ts
+++ b/tests/ui/testIndexPage.spec.ts
@@ -1,6 +1,14 @@
 import { expect } from '@playwright/test'
-import test from './base'
+import test, { mockAPIRequests } from './base'
 import testIDs from '../../src/ui/interfacesAndTypes/testIDs'
+
+test.beforeEach(async ({ page }) => {
+  await mockAPIRequests(page)
+})
+
+test.afterEach(async ({ page }) => {
+  await page.unrouteAll()
+})
 
 test('Test navigation index to documentation to version overview', async ({ page }) => {
   await page.goto('/')

--- a/tests/ui/testLinkSubstitution.spec.ts
+++ b/tests/ui/testLinkSubstitution.spec.ts
@@ -1,24 +1,19 @@
 import { expect } from '@playwright/test'
 import test from './base'
-import testIDs from '../../src/ui/interfacesAndTypes/testIDs'
+import { openProjectDocumentation } from './helpers'
 
 test('Test link substitution', async ({ page }) => {
-  await page.goto('/')
-
-  const docIframe = page.getByTestId(testIDs.project.documentation.documentationIframe)
-  const expectedDocumentationContent = 'Hello, this is a mocked documentation component.'
-  const basePath = 'http://localhost:3000'
+  const documentation = await openProjectDocumentation(page, 'example-project-01', 'latest')
 
   // Expect the documentation iframe to display the mocked documentation page
-  await page.goto('/example-project-01/latest')
-  await expect(docIframe.contentFrame().locator('html')).toContainText(expectedDocumentationContent)
+  await expect(documentation).toContainText('Hello, this is a mocked documentation component.')
 
   // Ensure that all links have been substituted correctly
-  const links = docIframe.contentFrame().getByRole('link')
+  const links = documentation.getByRole('link')
   await expect(links).toHaveCount(3)
   const expectedSubstitutedLinks = [
-    `${basePath}/example-project-01/latest/#`,
-    `${basePath}/example-project-01/latest/index.html`,
+    'http://localhost:3000/example-project-01/latest/#',
+    'http://localhost:3000/example-project-01/latest/index.html',
     'https://www.sphinx-doc.org/',
   ]
   for (const [index, expectedLink] of expectedSubstitutedLinks.entries()) {

--- a/tests/ui/testLinkSubstitution.spec.ts
+++ b/tests/ui/testLinkSubstitution.spec.ts
@@ -1,14 +1,8 @@
 import { expect } from '@playwright/test'
-import test, { mockAPIRequests } from './base'
+import test, { prepareTestSuite } from './base'
 import { openProjectDocumentation } from './helpers'
 
-test.beforeEach(async ({ page }) => {
-  await mockAPIRequests(page)
-})
-
-test.afterEach(async ({ page }) => {
-  await page.unrouteAll()
-})
+await prepareTestSuite(test)
 
 test('Test link substitution', async ({ page }) => {
   const documentation = await openProjectDocumentation(page, 'example-project-01', 'latest')

--- a/tests/ui/testLinkSubstitution.spec.ts
+++ b/tests/ui/testLinkSubstitution.spec.ts
@@ -1,6 +1,14 @@
 import { expect } from '@playwright/test'
-import test from './base'
+import test, { mockAPIRequests } from './base'
 import { openProjectDocumentation } from './helpers'
+
+test.beforeEach(async ({ page }) => {
+  await mockAPIRequests(page)
+})
+
+test.afterEach(async ({ page }) => {
+  await page.unrouteAll()
+})
 
 test('Test link substitution', async ({ page }) => {
   const documentation = await openProjectDocumentation(page, 'example-project-01', 'latest')

--- a/tests/ui/testToggleColorMode.spec.ts
+++ b/tests/ui/testToggleColorMode.spec.ts
@@ -1,6 +1,14 @@
-import test from './base'
+import test, { mockAPIRequests } from './base'
 import { ColorMode, EffectiveColorMode } from '../../src/ui/interfacesAndTypes/ColorModes'
 import { assertCurrentColorModeButton, assertTheme, switchColorMode } from './helpers'
+
+test.beforeEach(async ({ page }) => {
+  await mockAPIRequests(page)
+})
+
+test.afterEach(async ({ page }) => {
+  await page.unrouteAll()
+})
 
 test.describe('Color schemes tests', () => {
   test('Color mode should be system by default', async ({ page }) => {

--- a/tests/ui/testToggleColorMode.spec.ts
+++ b/tests/ui/testToggleColorMode.spec.ts
@@ -1,14 +1,8 @@
-import test, { mockAPIRequests } from './base'
-import { ColorMode, EffectiveColorMode } from '../../src/ui/interfacesAndTypes/ColorModes'
+import test, { prepareTestSuite } from './base'
+import type { ColorMode, EffectiveColorMode } from '../../src/ui/interfacesAndTypes/ColorModes'
 import { assertCurrentColorModeButton, assertTheme, switchColorMode } from './helpers'
 
-test.beforeEach(async ({ page }) => {
-  await mockAPIRequests(page)
-})
-
-test.afterEach(async ({ page }) => {
-  await page.unrouteAll()
-})
+await prepareTestSuite(test)
 
 test.describe('Color schemes tests', () => {
   test('Color mode should be system by default', async ({ page }) => {


### PR DESCRIPTION
- fix(tests): Setup and tear down playwright mocks per spec file 46356af
- refactor(tests): Add and use `openProjectDocumentation` helper function 7ad03b4
- tests: Set playwright retries to 0 in order to detect flakyness earlier 2ae3a9b
- refactor(tests): Add test setup method `prepareTestSuite` and fix imports b701c92