### PR TITLE
ci: Don't upload coverage on dependabot builds

### DIFF
--- a/.github/workflows/tests_and_coverage.yml
+++ b/.github/workflows/tests_and_coverage.yml
@@ -117,6 +117,7 @@ jobs:
   upload-coverage:
     timeout-minutes: 2
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     needs:
       - test-ui-unit
       - coverage-python


### PR DESCRIPTION
The token is undefined on dependabot builds due to security reasons.