### PR TITLE
fix(ui): Link substitution, navigation and error handling

### DIFF
--- a/src/ui/__tests__/helpers/routeHelpers.test.ts
+++ b/src/ui/__tests__/helpers/routeHelpers.test.ts
@@ -2,7 +2,7 @@ import { expect, test, describe } from 'vitest'
 import { sanitizeDocuUri } from '../../helpers/RouteHelpers'
 
 describe('sanitizeDocuUri', () => {
-  test('sanitizes uris as expected', () => {
+  test('sanitizes valid uris as expected', () => {
     const basePath = 'http://localhost:8080'
     const testData = [
       {
@@ -12,10 +12,9 @@ describe('sanitizeDocuUri', () => {
           projectVersion: '6.0',
         },
         expected: {
-          isInternal: true,
-          project: 'project-one',
-          remainder: 'index.html#',
+          projectName: 'project-one',
           version: '6.0',
+          _splat: 'index.html#',
           href: `${basePath}/project-one/6.0/index.html#`,
         },
       },
@@ -26,10 +25,9 @@ describe('sanitizeDocuUri', () => {
           projectVersion: '1.3.0',
         },
         expected: {
-          isInternal: true,
-          project: 'meta-project',
-          remainder: '#',
+          projectName: 'meta-project',
           version: '1.3.0',
+          _splat: '#',
           href: `${basePath}/meta-project/1.3.0/#`,
         },
       },
@@ -40,10 +38,9 @@ describe('sanitizeDocuUri', () => {
           projectVersion: '1.3.0',
         },
         expected: {
-          isInternal: true,
-          project: 'meta-project',
-          remainder: undefined,
+          projectName: 'meta-project',
           version: '1.3.0',
+          _splat: '',
           href: `${basePath}/meta-project/1.3.0`,
         },
       },
@@ -54,10 +51,9 @@ describe('sanitizeDocuUri', () => {
           projectVersion: 'latest',
         },
         expected: {
-          isInternal: true,
-          project: 'project-one',
-          remainder: 'examples.html#examples',
+          projectName: 'project-one',
           version: 'latest',
+          _splat: 'examples.html#examples',
           href: `${basePath}/project-one/latest/examples.html#examples`,
         },
       },
@@ -68,27 +64,22 @@ describe('sanitizeDocuUri', () => {
           projectVersion: 'latest',
         },
         expected: {
-          isInternal: true,
-          project: 'project-one',
-          remainder: 'examples.html#examples',
+          projectName: 'project-one',
           version: 'latest',
+          _splat: 'examples.html#examples',
           href: `${basePath}/project-one/latest/examples.html#examples`,
-        },
-      },
-      {
-        input: {
-          href: 'https://www.sphinx-doc.org/',
-          projectName: 'example-project',
-          projectVersion: "doesn't matter",
-        },
-        expected: {
-          isInternal: false,
-          href: 'https://www.sphinx-doc.org/',
         },
       },
     ]
     testData.forEach(({ input, expected }) => {
       expect(sanitizeDocuUri(input.href, basePath, input.projectName, input.projectVersion)).toStrictEqual(expected)
+    })
+  })
+  test('sanitizing invalid or external uris must throw errors', () => {
+    const basePath = 'http://localhost:8080'
+    const testData = ['https://google.com', 'http://localhost:9000']
+    testData.forEach((href) => {
+      expect(() => sanitizeDocuUri(href, basePath, '', '')).toThrowError(`Unable to sanitize doc URI ${href}`)
     })
   })
 })

--- a/src/ui/helpers/RouteHelpers.ts
+++ b/src/ui/helpers/RouteHelpers.ts
@@ -1,8 +1,7 @@
 export interface SanitizeDocUriResI {
-  project?: string
-  version?: string
-  remainder?: string
-  isInternal: boolean
+  projectName: string
+  version: string
+  _splat: string
   href: string
 }
 export const sanitizeDocuUri = (
@@ -21,14 +20,15 @@ export const sanitizeDocuUri = (
     String.raw`^${escapedBasePath}(?:\/static)?(?:\/projects)?\/(?<name>[^\/]+)\/(?<version>[^\/#?\n]+)(?:\/(?<remainder>.*?))?(?:\n|$)`
   )
   const match = href.match(re)
-  if (match && match.groups) {
-    const { name, version, remainder } = match.groups
-    const url = new URL(`${name}/${version}${remainder ? `/${remainder}` : ''}`, basePath)
-    return { project: name, version, remainder, isInternal: true, href: url.href }
-  } else if (!href.startsWith('http')) {
-    const url = new URL(`${projectName}/${projectVersion}/${href}`, basePath)
-    return { remainder: href, isInternal: true, href: url.href }
-  } else {
-    return { isInternal: false, href: href }
+
+  if (!match?.groups) {
+    throw new Error(`Unable to sanitize doc URI ${href}`)
+  }
+  const remainder = match.groups.remainder || ''
+  return {
+    projectName: projectName,
+    version: projectVersion,
+    _splat: remainder,
+    href: `${basePath}/${projectName}/${projectVersion}${remainder ? `/${remainder}` : ''}`,
   }
 }

--- a/src/ui/routes/$projectName/$version.$.tsx
+++ b/src/ui/routes/$projectName/$version.$.tsx
@@ -106,7 +106,6 @@ function DocuIFrame({ name, version, latestVersion, splat }: DocuIFramePropsI) {
     }
 
     const checkForErrors = (iframeDocument: Document) => {
-      console.log(iframeDocument.body.innerHTML)
       if (iframeDocument.body.innerText === '{"detail":"Not Found"}') {
         throw new Error("Whoops! This page doesn't seem to exist...")
       }

--- a/tests/resources/sample-docs/meta-project/features.rst
+++ b/tests/resources/sample-docs/meta-project/features.rst
@@ -1,0 +1,4 @@
+Features
+********
+
+The meta project doesn't include any cool features... Sorry.

--- a/tests/resources/sample-docs/meta-project/index.rst
+++ b/tests/resources/sample-docs/meta-project/index.rst
@@ -10,3 +10,12 @@ This project depends on :ref:`project-one <project-one:index>`. and :ref:`projec
 There are some examples on how to use :ref:`project-one <project-one:examples>`.
 
 You can see the usage page of project two :ref:`here <project-two:usage>`.
+
+
+Contents
+========
+
+.. toctree::
+   :maxdepth: 2
+
+   features

--- a/tests/ui/base.ts
+++ b/tests/ui/base.ts
@@ -26,8 +26,12 @@ export const prepareTestSuite = async (
 export const mockAPIRequests = async (page: Page) => {
   const routes = [
     {
-      pattern: '*/**/static/projects/*/*/',
+      pattern: '*/**/static/projects/**/*',
       response: { body: fs.readFileSync(path.resolve('tests/ui/resources/mockedIndex.html')) },
+    },
+    {
+      pattern: '*/**/static/projects/**/examples.html',
+      response: { body: fs.readFileSync(path.resolve('tests/ui/resources/mockedExamples.html')) },
     },
     {
       pattern: '*/**/static/projects/**/style.css',

--- a/tests/ui/base.ts
+++ b/tests/ui/base.ts
@@ -30,6 +30,10 @@ export const mockAPIRequests = async (page: Page) => {
       response: { body: fs.readFileSync(path.resolve('tests/ui/resources/mockedIndex.html')) },
     },
     {
+      pattern: '*/**/static/projects/**/style.css',
+      response: { body: fs.readFileSync(path.resolve('tests/ui/resources/style.css')) },
+    },
+    {
       pattern: '*/**/static/projects/example-project-03/1.0.0/nonexisting.html',
       response: { body: fs.readFileSync(path.resolve('tests/ui/resources/nonExisting.html')) },
     },

--- a/tests/ui/helpers.ts
+++ b/tests/ui/helpers.ts
@@ -5,6 +5,22 @@ import testIDs from '../../src/ui/interfacesAndTypes/testIDs'
 import { themes } from './base'
 
 /**
+ * Expects the given hyperlinks to be visible on the page in the given order.
+ *
+ * @param locator The playwright locator that must include the expected links.
+ * @param links The expected links to be visible on the page.
+ *
+ * @returns The link locators.
+ */
+export const assertLinksOnPage = async (locator: Locator, links: string[]): Promise<Locator> => {
+  const availableLinks = locator.getByRole('link')
+  await expect(availableLinks).toHaveCount(links.length)
+  const actualLinks = await availableLinks.evaluateAll((links) => links.map((link) => link.getAttribute('href')))
+  expect(actualLinks).toStrictEqual(links)
+  return availableLinks
+}
+
+/**
  * Expects that the index/home page is visible including all project cards.
  *
  * @param page The playwright page object.

--- a/tests/ui/helpers.ts
+++ b/tests/ui/helpers.ts
@@ -138,6 +138,8 @@ export const openProjectDocumentation = async (page: Page, name: string, version
 
   await page.goto(`/${name}/${version}`)
 
+  await expect(page).toHaveURL(`http://localhost:3000/${name}/${version}`)
+
   await expect(docIframe).toBeVisible({ timeout: 10000 })
 
   await docIframe.waitFor({ state: 'attached' })

--- a/tests/ui/resources/mockedExamples.html
+++ b/tests/ui/resources/mockedExamples.html
@@ -1,0 +1,14 @@
+<html>
+  <head>
+    <link rel="stylesheet" type="text/css" href="style.css" />
+  </head>
+  <body>
+    <h1>This is a mocked examples page</h1>
+    <ul>
+      <li>Example 01</li>
+      <li>Example 02</li>
+      <li>Example 03</li>
+      <li><a href="index.html">Take me back to 'index.html'</a></li>
+    </ul>
+  </body>
+</html>

--- a/tests/ui/resources/mockedIndex.html
+++ b/tests/ui/resources/mockedIndex.html
@@ -1,20 +1,7 @@
 <html>
-  <style>
-    .light {
-      background-color: rgb(227, 242, 253);
-      color: black;
-    }
-    .light a {
-      color: blue;
-    }
-    .dark {
-      background-color: rgb(18, 18, 18);
-      color: white;
-    }
-    .dark a {
-      color: lightblue;
-    }
-  </style>
+  <head>
+    <link rel="stylesheet" type="text/css" href="style.css" />
+  </head>
   <body>
     <h1>Hello, this is a mocked documentation component.</h1>
     <ul>

--- a/tests/ui/resources/mockedIndex.html
+++ b/tests/ui/resources/mockedIndex.html
@@ -7,6 +7,7 @@
     <ul>
       <li><a href="#">Link with href '#'</a></li>
       <li><a href="index.html">Link with href 'index.html'</a></li>
+      <li><a href="examples.html">Link with href 'examples.html'</a></li>
       <li><a href="https://www.sphinx-doc.org/">Link with href 'https://www.sphinx-doc.org/'</a></li>
     </ul>
     <script>

--- a/tests/ui/resources/style.css
+++ b/tests/ui/resources/style.css
@@ -1,0 +1,17 @@
+.light {
+    background-color: rgb(227, 242, 253);
+    color: black;
+}
+
+.light a {
+    color: blue;
+}
+
+.dark {
+    background-color: rgb(18, 18, 18);
+    color: white;
+}
+
+.dark a {
+    color: lightblue;
+}

--- a/tests/ui/resources/style.css
+++ b/tests/ui/resources/style.css
@@ -1,17 +1,17 @@
 .light {
-    background-color: rgb(227, 242, 253);
-    color: black;
+  background-color: rgb(227, 242, 253);
+  color: black;
 }
 
 .light a {
-    color: blue;
+  color: blue;
 }
 
 .dark {
-    background-color: rgb(18, 18, 18);
-    color: white;
+  background-color: rgb(18, 18, 18);
+  color: white;
 }
 
 .dark a {
-    color: lightblue;
+  color: lightblue;
 }

--- a/tests/ui/testLinkSubstitution.spec.ts
+++ b/tests/ui/testLinkSubstitution.spec.ts
@@ -10,11 +10,29 @@ test('Test link substitution', async ({ page }) => {
   // Expect the documentation iframe to display the mocked documentation page
   await expect(documentation).toContainText('Hello, this is a mocked documentation component.')
 
+  const baseUrl = 'http://localhost:3000/example-project-01/latest'
+
   // Ensure that all links have been substituted correctly
   let linkLocators = await assertLinksOnPage(documentation, [
-    'http://localhost:3000/example-project-01/latest/#',
-    'http://localhost:3000/example-project-01/latest/index.html',
-    'http://localhost:3000/example-project-01/latest/examples.html',
+    `${baseUrl}/#`,
+    `${baseUrl}/index.html`,
+    `${baseUrl}/examples.html`,
+    'https://www.sphinx-doc.org/',
+  ])
+
+  // Go to the examples page
+  await linkLocators.nth(2).click()
+  await expect(page).toHaveURL(`${baseUrl}/examples.html`)
+
+  linkLocators = await assertLinksOnPage(documentation, [`${baseUrl}/index.html`])
+
+  await linkLocators.first().click()
+  await expect(page).toHaveURL(`${baseUrl}/index.html`)
+
+  linkLocators = await assertLinksOnPage(documentation, [
+    `${baseUrl}/index.html#`,
+    `${baseUrl}/index.html`,
+    `${baseUrl}/examples.html`,
     'https://www.sphinx-doc.org/',
   ])
 })

--- a/tests/ui/testLinkSubstitution.spec.ts
+++ b/tests/ui/testLinkSubstitution.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 import test, { prepareTestSuite } from './base'
-import { openProjectDocumentation } from './helpers'
+import { openProjectDocumentation, assertLinksOnPage } from './helpers'
 
 await prepareTestSuite(test)
 
@@ -11,14 +11,10 @@ test('Test link substitution', async ({ page }) => {
   await expect(documentation).toContainText('Hello, this is a mocked documentation component.')
 
   // Ensure that all links have been substituted correctly
-  const links = documentation.getByRole('link')
-  await expect(links).toHaveCount(3)
-  const expectedSubstitutedLinks = [
+  let linkLocators = await assertLinksOnPage(documentation, [
     'http://localhost:3000/example-project-01/latest/#',
     'http://localhost:3000/example-project-01/latest/index.html',
+    'http://localhost:3000/example-project-01/latest/examples.html',
     'https://www.sphinx-doc.org/',
-  ]
-  for (const [index, expectedLink] of expectedSubstitutedLinks.entries()) {
-    expect(await links.nth(index).getAttribute('href')).toBe(expectedLink)
-  }
+  ])
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
       include: ['src/ui/helpers/'],
       reportsDirectory: 'coverage/ui/unit/',
     },
-    reporters: ['junit'],
+    reporters: ['junit', 'default'],
     outputFile: './reports/coverage-vitest.xml',
   },
 })


### PR DESCRIPTION
Properly substitutes hrefs in the iframe and handles navigation errors (such as invalid paths/non-existing pages).

https://github.com/user-attachments/assets/f47a869c-4ce2-4f35-b097-e16d4b70d4f7

This still doesn't fix https://github.com/vorausrobotik/vdoc/issues/63

