### PR TITLE
fix: Do not return parsed `packaging.version.Version` objects but str…

### DIFF
--- a/src/vdoc/methods/api/projects.py
+++ b/src/vdoc/methods/api/projects.py
@@ -46,7 +46,7 @@ def get_project_version_impl(name: str, version: str) -> str:
         The requested version of the project.
     """
     parsed_version, _ = Project.get_version_and_docs_path(name=name, version=version)
-    return str(parsed_version)
+    return parsed_version
 
 
 def upload_project_version_impl(name: str, version: str, file: UploadFile) -> JSONResponse:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ from vdoc.constants import CONFIG_ENV_PREFIX, DEFAULT_API_PASSWORD, DEFAULT_API_
 DUMMY_VERSIONS = (
     ("0.0.1", "0.0.2", "0.1.0", "1.0.0", "1.1.0", "2.0.0"),
     ("6.0", "1.0", "3.6", "5.9.9"),
-    ("1.0.0", "1.3.0"),
+    ("1.0.0", "1.3.0", "2.0.0-beta"),
 )
 
 DUMMY_DOCS_STRUCTURE = {

--- a/tests/unit/methods/api/test_project_methods.py
+++ b/tests/unit/methods/api/test_project_methods.py
@@ -2,8 +2,19 @@
 
 from pathlib import Path
 
+import pytest
+
 from vdoc.methods.api.projects import get_project_version_impl
 
 
-def test_get_project_version_impl(dummy_projects_dir: Path) -> None:  # pylint: disable=unused-argument
-    assert get_project_version_impl("dummy-project-01", "latest") == "2.0.0"
+@pytest.mark.parametrize(
+    ["project_name", "requested_version", "expected_version"],
+    [("dummy-project-01", "latest", "2.0.0"), ("dummy-project-03", "2.0.0-beta", "2.0.0-beta")],
+)
+def test_get_project_version_impl(
+    dummy_projects_dir: Path,  # pylint: disable=unused-argument
+    project_name: str,
+    requested_version: str,
+    expected_version: str,
+) -> None:
+    assert get_project_version_impl(project_name, requested_version) == expected_version

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -16,28 +16,25 @@ def test_list_projects(dummy_projects_dir: Path) -> None:  # pylint: disable=unu
 
 
 def test_list_project_versions(dummy_projects_dir: Path) -> None:  # pylint: disable=unused-argument
-    assert Project(name="dummy-project-01").versions == [
-        Version("0.0.1"),
-        Version("0.0.2"),
-        Version("0.1.0"),
-        Version("1.0.0"),
-        Version("1.1.0"),
-        Version("2.0.0"),
-    ]
+    assert Project(name="dummy-project-03").versions == {
+        Version("1.0.0"): "1.0.0",
+        Version("1.3.0"): "1.3.0",
+        Version("2.0.0-b0"): "2.0.0-beta",
+    }
 
 
 def test_get_project_latest_version(dummy_projects_dir: Path) -> None:  # pylint: disable=unused-argument
-    assert Project(name="dummy-project-02").latest == Version("6.0.0")
+    assert Project(name="dummy-project-03").latest == "2.0.0-beta"
 
 
 def test_get_version_and_docs_path(dummy_projects_dir: Path) -> None:  # pylint: disable=unused-argument
-    assert (Version("1.0.0"), dummy_projects_dir / "dummy-project-01" / "1.0.0") == Project.get_version_and_docs_path(
+    assert ("1.0.0", dummy_projects_dir / "dummy-project-01" / "1.0.0") == Project.get_version_and_docs_path(
         name="dummy-project-01", version="1.0.0"
     )
 
 
 def test_get_version_and_docs_path_latest(dummy_projects_dir: Path) -> None:  # pylint: disable=unused-argument
-    assert (Version("2.0.0"), dummy_projects_dir / "dummy-project-01" / "2.0.0") == Project.get_version_and_docs_path(
+    assert ("2.0.0", dummy_projects_dir / "dummy-project-01" / "2.0.0") == Project.get_version_and_docs_path(
         name="dummy-project-01", version="latest"
     )
 


### PR DESCRIPTION
…ings

Python's `packaging.version.Version` parses pre releases in a short-hand notation, e.g. `2.0.0-beta` is parsed to `2.0.0-b0`. Since the directory structure uses the actual git tag, there is a 404 error when requesting `/static/projects/<name>/<parsed-tag>` since the directory name differs.

With this PR, the tags are still being validated to be SemVer, but the returned version string is the directory name (and therefore the git tag).

This fixes #70.