### PR TITLE
feat: Make project display names configurable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,3 +100,6 @@ All configuration environment variables are prefixed with ``VDOC_``:
    * - ``VDOC_BIND_ADDRESS``
      - The application bind port.
      - ``8080``
+   * - ``VDOC_PROJECT_DISPLAY_NAME_MAPPING``
+     - An optional mapping (dictionary) of project names to display names.
+     - ``{}``

--- a/src/ui/interfacesAndTypes/Project.ts
+++ b/src/ui/interfacesAndTypes/Project.ts
@@ -1,3 +1,4 @@
 export interface Project {
   name: string
+  display_name: string
 }

--- a/src/ui/interfacesAndTypes/testIDs.ts
+++ b/src/ui/interfacesAndTypes/testIDs.ts
@@ -30,6 +30,7 @@ export const testIDs = {
     main: 'landingPage',
     projectCard: {
       main: 'landingPage.projectCard',
+      title: 'landingPage.projectCard.title',
       actions: {
         main: 'landingPage.projectCard.actions',
         documentationLink: 'landingPage.projectCard.actions.openDocumentation',

--- a/src/ui/routes/index.lazy.tsx
+++ b/src/ui/routes/index.lazy.tsx
@@ -26,8 +26,12 @@ function Index() {
             <Grid2 key={project.name} size={{ xs: 6, md: 4, lg: 3 }}>
               <Card sx={{ minHeight: 140 }} data-testid={testIDs.landingPage.projectCard.main}>
                 <CardContent>
-                  <Typography gutterBottom sx={{ color: 'text.secondary', fontSize: 14 }}>
-                    {project.name}
+                  <Typography
+                    gutterBottom
+                    sx={{ color: 'text.secondary', fontSize: 14 }}
+                    data-testid={testIDs.landingPage.projectCard.title}
+                  >
+                    {project.display_name}
                   </Typography>
                 </CardContent>
                 <CardActions data-testid={testIDs.landingPage.projectCard.actions.main}>

--- a/src/vdoc/models/project.py
+++ b/src/vdoc/models/project.py
@@ -8,7 +8,7 @@ from typing import Dict
 
 from packaging.version import InvalidVersion as PackagingInvalidVersion
 from packaging.version import Version
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, computed_field, field_validator
 
 from vdoc.exceptions import InvalidVersion, ProjectNotFound, ProjectVersionNotFound
 from vdoc.settings import VDocSettings
@@ -97,6 +97,17 @@ class Project(BaseModel):
                 raise ProjectVersionNotFound(name=name, version=parsed_version)
 
         return return_version, project._base_path / return_version  # Path existence is validated at object construction
+
+    @computed_field  # type: ignore[prop-decorator]  # https://docs.pydantic.dev/2.0/usage/computed_fields/
+    @cached_property
+    def display_name(self) -> str:
+        """Returns the display name of the project if configured, otherwise the project name.
+
+        Returns:
+            str: The project display name.
+        """
+        settings = VDocSettings()
+        return settings.project_display_name_mapping.get(self.name, self.name)
 
     @property
     def versions(self) -> Dict[Version, str]:

--- a/src/vdoc/settings/__init__.py
+++ b/src/vdoc/settings/__init__.py
@@ -24,3 +24,5 @@ class VDocSettings(BaseSettings):
     api_password: bytes = DEFAULT_API_PASSWORD
     bind_address: str = DEFAULT_BIND_ADDRESS
     bind_port: int = DEFAULT_BIND_PORT
+
+    project_display_name_mapping: dict[str, str] = {}

--- a/tests/ui/base.ts
+++ b/tests/ui/base.ts
@@ -44,7 +44,11 @@ export const mockAPIRequests = async (page: Page) => {
     {
       pattern: '*/**/api/projects/',
       response: {
-        json: [{ name: 'example-project-01' }, { name: 'example-project-02' }, { name: 'example-project-03' }],
+        json: [
+          { name: 'example-project-01', display_name: 'Example Project 01' },
+          { name: 'example-project-02', display_name: 'example-project-02' },
+          { name: 'example-project-03', display_name: 'example-project-03' },
+        ],
       },
     },
     {

--- a/tests/ui/testIndexPage.spec.ts
+++ b/tests/ui/testIndexPage.spec.ts
@@ -14,7 +14,11 @@ test('Test navigation index to documentation to version overview', async ({ page
   const latestVersionWarningBanner = page.getByTestId(testIDs.project.documentation.latestVersionWarningBanner)
 
   // Expect three projects on the main page with links to the docs
-  await expect(projectCards).toHaveCount(3)
+  const expectedDisplayNames = ['Example Project 01', 'example-project-02', 'example-project-03']
+  await expect(projectCards).toHaveCount(expectedDisplayNames.length)
+  for (const [index, value] of expectedDisplayNames.entries()) {
+    await expect(projectCards.nth(index).getByTestId(testIDs.landingPage.projectCard.title)).toContainText(value)
+  }
   await expect(versionDropdown).not.toBeVisible()
   await expect(docIframe).not.toBeVisible()
   const documentationButton = projectCards.nth(0).getByTestId(testIDs.landingPage.projectCard.actions.documentationLink)

--- a/tests/unit/api/routes/test_project_routes.py
+++ b/tests/unit/api/routes/test_project_routes.py
@@ -1,5 +1,6 @@
 """Contains all unit tests for the projects REST API."""
 
+import os
 import zipfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -12,12 +13,17 @@ from vdoc.exceptions import ProjectVersionNotFound
 from vdoc.models.project import Project
 
 
+@patch.dict(os.environ, {"VDOC_PROJECT_DISPLAY_NAME_MAPPING": '{"dummy-project-01": "Dummy Project 01"}'})
 @patch("vdoc.api.routes.projects.list_projects_impl")
 def test_list_projects_route(list_projects_impl_mock: MagicMock, dummy_projects_dir: Path, api: TestClient) -> None:
     mocked_projects = Project.list(search_path=dummy_projects_dir)
     list_projects_impl_mock.return_value = mocked_projects
     response = api.get("/api/projects/")
-    assert response.json() == [{"name": "dummy-project-01"}, {"name": "dummy-project-02"}, {"name": "dummy-project-03"}]
+    assert response.json() == [
+        {"name": "dummy-project-01", "display_name": "Dummy Project 01"},
+        {"name": "dummy-project-02", "display_name": "dummy-project-02"},
+        {"name": "dummy-project-03", "display_name": "dummy-project-03"},
+    ]
     list_projects_impl_mock.assert_called_once_with()
 
 

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -1,6 +1,8 @@
 """Contains all tests for the project models."""
 
+import os
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from packaging.version import Version
@@ -8,6 +10,12 @@ from packaging.version import Version
 from tests.conftest import DUMMY_DOCS_STRUCTURE
 from vdoc.exceptions import InvalidVersion, ProjectVersionNotFound
 from vdoc.models.project import Project
+
+
+@patch.dict(os.environ, {"VDOC_PROJECT_DISPLAY_NAME_MAPPING": '{"dummy-project-01": "Dummy Project 01"}'})
+def test_project_display_name(dummy_projects_dir: Path) -> None:  # pylint: disable=unused-argument
+    assert Project(name="dummy-project-01").display_name == "Dummy Project 01"
+    assert Project(name="dummy-project-02").display_name == "dummy-project-02"
 
 
 def test_list_projects(dummy_projects_dir: Path) -> None:  # pylint: disable=unused-argument


### PR DESCRIPTION
Project display names can be provided by setting the environment variable `VDOC_PROJECT_DISPLAY_NAME_MAPPING`, e.g.

```bash
VDOC_PROJECT_DISPLAY_NAME_MAPPING='{"project-name": "Display Name"}'
```

This is a temporary solution which can be replaced by a proper database structure.