### PR TITLE
feat: Configurable project categories

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,3 +117,12 @@ All configuration environment variables are prefixed with ``VDOC_``:
    * - ``VDOC_PROJECT_DISPLAY_NAME_MAPPING``
      - An optional mapping (dictionary) of project names to display names.
      - ``{}``
+     - ``{"project-01": "Project Name", "project-02": "Another Project Name"}``
+   * - ``VDOC_PROJECT_CATEGORIES``
+     - An optional list of project categories.
+     - ``[]``
+     - ``[{"name": "Category 1", "id": "0"}]``
+   * - ``VDOC_PROJECT_CATEGORY_MAPPING``
+     - An optional list of of project mappings.
+     - ``{}``
+     - ``{"project-01": "Category 1"}``

--- a/README.rst
+++ b/README.rst
@@ -79,33 +79,41 @@ All configuration environment variables are prefixed with ``VDOC_``:
 
 
 .. list-table:: VDoc Configuration
-   :widths: 25 50 25
+   :widths: 25 25 25 25
    :header-rows: 1
 
    * - Environment variable
      - Explanation
      - Default
+     - Example
    * - ``VDOC_DOCS_DIR``
      - The directory to which all project documentations will be uploaded.
      - ``/srv/vdoc/docs/``
+     - ``/path/to/your/docs/```
    * - ``VDOC_API_USERNAME``
      - The username required for uploading documentations via the API.
      - ``admin``
+     - ``Something more secure``
    * - ``VDOC_API_PASSWORD``
      - The password required for uploading documentations via the API.
      - ``admin``
+     - ``sup3r_s3cr3t``
    * - ``VDOC_BIND_ADDRESS``
      - The application bind address.
      - ``0.0.0.0``
-   * - ``VDOC_BIND_ADDRESS``
+     - ``127.0.0.1``
+   * - ``VDOC_BIND_PORT``
      - The application bind port.
      - ``8080``
+     - ``1337``
    * - ``VDOC_LOGO_LIGHT_URL``
      - The URL to the light logo.
      - ``https://logos.vorausrobotik.com/v_rgb.png``
+     - ``https://example.com/light-mode-logo.png``
    * - ``VDOC_LOGO_DARK_URL``
      - The URL to the dark logo.
      - ``https://logos.vorausrobotik.com/v_rgb.png``
+     - ``https://example.com/dark-mode-logo.png``
    * - ``VDOC_PROJECT_DISPLAY_NAME_MAPPING``
      - An optional mapping (dictionary) of project names to display names.
      - ``{}``

--- a/src/ui/helpers/APIFunctions.ts
+++ b/src/ui/helpers/APIFunctions.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { Project } from '../interfacesAndTypes/Project'
+import type { Project, ProjectCategory } from '../interfacesAndTypes/Project'
 import { EffectiveColorMode } from '../interfacesAndTypes/ColorModes'
 
 export const fetchProjectVersion = async (projectName: string, version: string): Promise<string> => {
@@ -16,4 +16,8 @@ export const fetchProjects = async (): Promise<Project[]> => {
 
 export const fetchLogoURL = async (mode: EffectiveColorMode): Promise<string | null> => {
   return (await axios.get(`/api/settings/logo_url/${mode}`)).data
+}
+
+export const fetchProjectCategories = async (): Promise<ProjectCategory[]> => {
+  return (await axios.get(`/api/project_categories/`)).data
 }

--- a/src/ui/helpers/Projects.ts
+++ b/src/ui/helpers/Projects.ts
@@ -1,0 +1,18 @@
+import type { Project, ProjectCategory } from '../interfacesAndTypes/Project'
+
+export function groupProjectsByCategories(
+  projects: Project[],
+  projectCategories: ProjectCategory[]
+): Record<string, Project[]> {
+  const grouped: Record<string, Project[]> = {}
+  const categoriesCopy = [...projectCategories, { id: null, name: 'Misc' }]
+
+  categoriesCopy.forEach((category) => {
+    const filteredProjects = projects.filter((project) => project.category_id === category.id)
+    if (filteredProjects.length > 0) {
+      grouped[category.name] = filteredProjects
+    }
+  })
+
+  return grouped
+}

--- a/src/ui/interfacesAndTypes/Project.ts
+++ b/src/ui/interfacesAndTypes/Project.ts
@@ -1,4 +1,10 @@
 export interface Project {
   name: string
   display_name: string
+  category_id: number
+}
+
+export interface ProjectCategory {
+  id: number
+  name: string
 }

--- a/src/ui/interfacesAndTypes/testIDs.ts
+++ b/src/ui/interfacesAndTypes/testIDs.ts
@@ -28,12 +28,23 @@ export const testIDs = {
   },
   landingPage: {
     main: 'landingPage',
-    projectCard: {
-      main: 'landingPage.projectCard',
-      title: 'landingPage.projectCard.title',
-      actions: {
-        main: 'landingPage.projectCard.actions',
-        documentationLink: 'landingPage.projectCard.actions.openDocumentation',
+    projectCategories: {
+      main: 'landingPage.projectCategories',
+      projectCategory: {
+        main: 'landingPage.projectCategories.projectCategory',
+        title: 'landingPage.projectCategories.projectCategory.title',
+        projects: {
+          main: 'landingPage.projectCategories.projectCategory.projects',
+          projectCard: {
+            main: 'landingPage.projectCategories.projectCategory.projects.projectCard',
+            title: 'landingPage.projectCategories.projectCategory.projects.projectCard.title',
+            actions: {
+              main: 'landingPage.projectCategories.projectCategory.projects.projectCard.actions',
+              documentationLink:
+                'landingPage.projectCategories.projectCategory.projects.projectCard.actions.openDocumentation',
+            },
+          },
+        },
       },
     },
   },

--- a/src/ui/routes/index.lazy.tsx
+++ b/src/ui/routes/index.lazy.tsx
@@ -1,54 +1,87 @@
+import { useMemo } from 'react'
 import { createLazyFileRoute } from '@tanstack/react-router'
 import { LinkButton } from '../interfacesAndTypes/LinkButton'
+import { groupProjectsByCategories } from '../helpers/Projects'
 import { Box, Container, Card, CardActions, CardContent, Grid2, Typography } from '@mui/material'
 import testIDs from '../interfacesAndTypes/testIDs'
-import { Project } from '../interfacesAndTypes/Project'
+import { Project, ProjectCategory } from '../interfacesAndTypes/Project'
 
 export const Route = createLazyFileRoute('/')({
   component: Index,
 })
 
 function Index() {
-  const projects: Project[] = Route.useLoaderData()
+  const [projects, projectCategories]: [Project[], ProjectCategory[]] = Route.useLoaderData()
+
+  const getGroupedProjects = useMemo(() => {
+    return groupProjectsByCategories(projects, projectCategories)
+  }, [projects, projectCategories])
   return (
     <Container sx={{ mt: 2 }}>
-      <Box sx={{ flexGrow: 1 }}>
-        <Grid2
-          container
-          direction="row"
-          sx={{
-            justifyContent: 'flex-start',
-            alignItems: 'center',
-          }}
-          spacing={2}
-        >
-          {projects.map((project) => (
-            <Grid2 key={project.name} size={{ xs: 6, md: 4, lg: 3 }}>
-              <Card sx={{ minHeight: 140 }} data-testid={testIDs.landingPage.projectCard.main}>
-                <CardContent>
-                  <Typography
-                    gutterBottom
-                    sx={{ color: 'text.secondary', fontSize: 14 }}
-                    data-testid={testIDs.landingPage.projectCard.title}
-                  >
-                    {project.display_name}
-                  </Typography>
-                </CardContent>
-                <CardActions data-testid={testIDs.landingPage.projectCard.actions.main}>
-                  <LinkButton
-                    data-testid={testIDs.landingPage.projectCard.actions.documentationLink}
-                    to={`/$projectName/$version/$`}
-                    params={{ projectName: project.name, version: 'latest' }}
-                    size="small"
-                  >
-                    Documentation
-                  </LinkButton>
-                </CardActions>
-              </Card>
-            </Grid2>
-          ))}
-        </Grid2>
-      </Box>
+      {Object.entries(getGroupedProjects)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([category, projects]) => (
+          <Box key={category} sx={{ mb: 4 }} data-testid={testIDs.landingPage.projectCategories.projectCategory.main}>
+            <Typography
+              variant="h6"
+              sx={{ mb: 2, textTransform: 'uppercase' }}
+              data-testid={testIDs.landingPage.projectCategories.projectCategory.title}
+            >
+              {category}
+            </Typography>
+            <Box sx={{ flexGrow: 1 }}>
+              <Grid2
+                container
+                direction="row"
+                sx={{
+                  justifyContent: 'flex-start',
+                  alignItems: 'center',
+                }}
+                spacing={2}
+                data-testid={testIDs.landingPage.projectCategories.projectCategory.projects.main}
+              >
+                {projects.map((project) => (
+                  <IndexProjectCard project={project} />
+                ))}
+              </Grid2>
+            </Box>
+          </Box>
+        ))}
     </Container>
+  )
+}
+
+function IndexProjectCard({ project }: { project: Project }) {
+  return (
+    <Grid2 key={project.name} size={{ xs: 6, md: 4, lg: 3 }}>
+      <Card
+        sx={{ minHeight: 120 }}
+        data-testid={testIDs.landingPage.projectCategories.projectCategory.projects.projectCard.main}
+      >
+        <CardContent>
+          <Typography
+            gutterBottom
+            sx={{ color: 'text.secondary', fontSize: 14 }}
+            data-testid={testIDs.landingPage.projectCategories.projectCategory.projects.projectCard.title}
+          >
+            {project.display_name}
+          </Typography>
+        </CardContent>
+        <CardActions
+          data-testid={testIDs.landingPage.projectCategories.projectCategory.projects.projectCard.actions.main}
+        >
+          <LinkButton
+            data-testid={
+              testIDs.landingPage.projectCategories.projectCategory.projects.projectCard.actions.documentationLink
+            }
+            to={`/$projectName/$version/$`}
+            params={{ projectName: project.name, version: 'latest' }}
+            size="small"
+          >
+            Documentation
+          </LinkButton>
+        </CardActions>
+      </Card>
+    </Grid2>
   )
 }

--- a/src/ui/routes/index.tsx
+++ b/src/ui/routes/index.tsx
@@ -1,15 +1,15 @@
 import { createFileRoute, useRouter } from '@tanstack/react-router'
-import { fetchProjects } from '../helpers/APIFunctions'
+import { fetchProjects, fetchProjectCategories } from '../helpers/APIFunctions'
 import ErrorComponent from '../components/ErrorComponent'
 import { SentimentDissatisfied } from '@mui/icons-material'
 
 export const Route = createFileRoute('/')({
   loader: async () => {
-    const projects = await fetchProjects()
+    const [projects, projectCategories] = await Promise.all([fetchProjects(), fetchProjectCategories()])
     if (projects.length === 0) {
       throw new Error('No projects found')
     }
-    return projects
+    return [projects, projectCategories]
   },
   errorComponent: ({ error }) => {
     const ErrorComponentWithRouter = () => {

--- a/src/vdoc/api/__init__.py
+++ b/src/vdoc/api/__init__.py
@@ -11,6 +11,7 @@ from starlette.requests import Request
 from starlette.responses import FileResponse
 from starlette.routing import BaseRoute
 
+from vdoc.api.routes import project_categories as PROJECT_CATEGORIES_MODULE
 from vdoc.api.routes import projects as PROJECTS_MODULE
 from vdoc.api.routes import settings as SETTINGS_MODULE
 from vdoc.exceptions import VDocException
@@ -48,6 +49,7 @@ app.add_middleware(
 
 app.include_router(PROJECTS_MODULE.router, prefix="/api")
 app.include_router(SETTINGS_MODULE.router, prefix="/api")
+app.include_router(PROJECT_CATEGORIES_MODULE.router, prefix="/api")
 
 
 @app.exception_handler(VDocException)

--- a/src/vdoc/api/routes/project_categories.py
+++ b/src/vdoc/api/routes/project_categories.py
@@ -1,0 +1,18 @@
+"""Contains all project category related REST API routes."""
+
+from fastapi import APIRouter
+
+from vdoc.methods.api.project_categories import list_project_categories_impl
+from vdoc.models.project_category import ProjectCategory
+
+router = APIRouter(prefix="/project_categories", tags=["Project Categories"])
+
+
+@router.get("/")
+def list_project_categories() -> list[ProjectCategory]:
+    """Lists all available project categories.
+
+    Returns:
+        A list of all available project categories.
+    """
+    return list_project_categories_impl()

--- a/src/vdoc/methods/api/project_categories.py
+++ b/src/vdoc/methods/api/project_categories.py
@@ -1,0 +1,13 @@
+"""Contains all projects REST API methods."""
+
+from vdoc.models.project_category import ProjectCategory
+from vdoc.settings import VDocSettings
+
+
+def list_project_categories_impl() -> list[ProjectCategory]:
+    """Lists all project categories.
+
+    Returns:
+        A list of all projects.
+    """
+    return VDocSettings().project_categories

--- a/src/vdoc/models/project.py
+++ b/src/vdoc/models/project.py
@@ -109,6 +109,19 @@ class Project(BaseModel):
         settings = VDocSettings()
         return settings.project_display_name_mapping.get(self.name, self.name)
 
+    @computed_field  # type: ignore[prop-decorator]  # https://docs.pydantic.dev/2.0/usage/computed_fields/
+    @cached_property
+    def category_id(self) -> int | None:
+        """Returns the category ID of the project if configured, otherwise None.
+
+        Returns:
+            int | None: The optional project category ID.
+        """
+        settings = VDocSettings()
+        if category_name := settings.project_category_mapping.get(self.name):
+            return next(category.id for category in settings.project_categories if category.name == category_name)
+        return None
+
     @property
     def versions(self) -> Dict[Version, str]:
         """Returns a list of all available project versions.

--- a/src/vdoc/models/project_category.py
+++ b/src/vdoc/models/project_category.py
@@ -1,0 +1,12 @@
+"""Contains the project category model."""
+
+from typing import Annotated
+
+from pydantic import BaseModel, Field
+
+
+class ProjectCategory(BaseModel):
+    """Pydantic model for a project category."""
+
+    id: Annotated[int, Field(ge=0)]
+    name: str

--- a/src/vdoc/settings/__init__.py
+++ b/src/vdoc/settings/__init__.py
@@ -1,8 +1,9 @@
 """Contains the settings definition."""
 
 from pathlib import Path
-from typing import Optional
+from typing import Self
 
+from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from vdoc.constants import (
@@ -15,6 +16,7 @@ from vdoc.constants import (
     DEFAULT_LOGO_DARK_URL,
     DEFAULT_LOGO_LIGHT_URL,
 )
+from vdoc.models.project_category import ProjectCategory
 
 
 class VDocSettings(BaseSettings):
@@ -30,5 +32,38 @@ class VDocSettings(BaseSettings):
 
     project_display_name_mapping: dict[str, str] = {}
 
-    logo_dark_url: Optional[str] = DEFAULT_LOGO_DARK_URL
-    logo_light_url: Optional[str] = DEFAULT_LOGO_LIGHT_URL
+    logo_dark_url: str | None = DEFAULT_LOGO_DARK_URL
+    logo_light_url: str | None = DEFAULT_LOGO_LIGHT_URL
+    project_categories: list[ProjectCategory] = []
+    project_category_mapping: dict[str, str] = {}
+
+    @model_validator(mode="after")
+    def validate_model(self) -> Self:
+        """Validates the model.
+
+        The following checks are performed:
+
+        - Ensures that all category IDs in `project_categories` are unique.
+        - Ensures that all category names in `project_categories` are unique.
+        - Ensures that all categories in `project_category_mapping` are defined in `project_categories`.
+
+        Raises:
+            ValueError: If any check fails.
+
+        Returns:
+            Self: The validated model.
+        """
+        project_category_ids = list(map(lambda category: category.id, self.project_categories))
+        project_category_names = list(map(lambda category: category.name, self.project_categories))
+        if len(set(project_category_ids)) != len(project_category_ids):
+            raise ValueError("Duplicate category IDs are not allowed in `project_categories`")
+        if len(set(project_category_names)) != len(project_category_names):
+            raise ValueError("Duplicate category names are not allowed in `project_categories`")
+        for category_name in self.project_category_mapping.values():
+            if category_name not in project_category_names:
+                raise ValueError(
+                    f"Category name '{category_name}' in `project_category_mapping` is "
+                    "not defined in `project_categories`"
+                )
+
+        return self

--- a/start_dev.py
+++ b/start_dev.py
@@ -20,7 +20,7 @@ def run_vite(port: int = 8090) -> None:
 
 def run_uvicorn(port: int = 8080) -> None:
     """Starts the uvicorn development server on the given port."""
-    uvicorn_run(app="vdoc.api:app", host="localhost", port=port, reload=True)
+    uvicorn_run(app="vdoc.api:app", host="localhost", port=port, reload=True, env_file=".env")
 
 
 def main() -> None:

--- a/tests/ui/base.ts
+++ b/tests/ui/base.ts
@@ -42,12 +42,18 @@ export const mockAPIRequests = async (page: Page) => {
       response: { body: fs.readFileSync(path.resolve('tests/ui/resources/nonExisting.html')) },
     },
     {
+      pattern: '*/**/api/project_categories/',
+      response: {
+        json: [{ id: 0, name: 'General' }],
+      },
+    },
+    {
       pattern: '*/**/api/projects/',
       response: {
         json: [
-          { name: 'example-project-01', display_name: 'Example Project 01' },
-          { name: 'example-project-02', display_name: 'example-project-02' },
-          { name: 'example-project-03', display_name: 'example-project-03' },
+          { name: 'example-project-01', display_name: 'Example Project 01', category_id: 0 },
+          { name: 'example-project-02', display_name: 'example-project-02', category_id: null },
+          { name: 'example-project-03', display_name: 'example-project-03', category_id: null },
         ],
       },
     },

--- a/tests/ui/testIndexPage.spec.ts
+++ b/tests/ui/testIndexPage.spec.ts
@@ -1,30 +1,33 @@
 import { expect } from '@playwright/test'
 import test, { prepareTestSuite } from './base'
 import testIDs from '../../src/ui/interfacesAndTypes/testIDs'
+import { assertIndexPage } from './helpers'
 
 await prepareTestSuite(test)
 
 test('Test navigation index to documentation to version overview', async ({ page }) => {
   await page.goto('/')
 
-  const projectCards = page.getByTestId(testIDs.landingPage.projectCard.main)
+  await assertIndexPage(page, {
+    categories: {
+      General: [{ name: 'example-project-01', display_name: 'Example Project 01', category_id: 0 }],
+      Misc: [{ name: 'example-project-02', display_name: 'example-project-02', category_id: -1 }],
+    },
+  })
+
+  const projectCards = page.getByTestId(testIDs.landingPage.projectCategories.projectCategory.projects.projectCard.main)
   const versionDropdown = page.getByTestId(testIDs.header.versionDropdown.main)
   const docIframe = page.getByTestId(testIDs.project.documentation.documentationIframe)
   const expectedDocumentationContent = 'Hello, this is a mocked documentation component.'
   const latestVersionWarningBanner = page.getByTestId(testIDs.project.documentation.latestVersionWarningBanner)
 
-  // Expect three projects on the main page with links to the docs
-  const expectedDisplayNames = ['Example Project 01', 'example-project-02', 'example-project-03']
-  await expect(projectCards).toHaveCount(expectedDisplayNames.length)
-  for (const [index, value] of expectedDisplayNames.entries()) {
-    await expect(projectCards.nth(index).getByTestId(testIDs.landingPage.projectCard.title)).toContainText(value)
-  }
   await expect(versionDropdown).not.toBeVisible()
   await expect(docIframe).not.toBeVisible()
-  const documentationButton = projectCards.nth(0).getByTestId(testIDs.landingPage.projectCard.actions.documentationLink)
+  const documentationButton = projectCards
+    .nth(0)
+    .getByTestId(testIDs.landingPage.projectCategories.projectCategory.projects.projectCard.actions.documentationLink)
   await expect(documentationButton).toBeVisible()
   await expect(latestVersionWarningBanner).not.toBeVisible()
-  await expect(documentationButton).toHaveText('Documentation')
 
   // Navigate to the latest documentation of example-project-01
   await documentationButton.click()
@@ -88,6 +91,6 @@ test('Test project overview on no projects', async ({ page }) => {
 
   // Expect the error component to be gone and a list of project cars to be present
   await expect(page.getByTestId(testIDs.errorComponent.main)).not.toBeVisible()
-  const projectCards = page.getByTestId(testIDs.landingPage.projectCard.main)
+  const projectCards = page.getByTestId(testIDs.landingPage.projectCategories.projectCategory.projects.projectCard.main)
   await expect(projectCards).toHaveCount(2)
 })

--- a/tests/unit/api/routes/test_project_category_routes.py
+++ b/tests/unit/api/routes/test_project_category_routes.py
@@ -1,0 +1,12 @@
+"""Contains all unit tests for the project categories REST API."""
+
+import os
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+
+@patch.dict(os.environ, {"VDOC_PROJECT_CATEGORIES": '[{"id": 1, "name": "General"}]'})
+def test_list_project_categories_route(api: TestClient) -> None:
+    response = api.get("/api/project_categories/")
+    assert response.json() == [{"name": "General", "id": 1}]

--- a/tests/unit/api/routes/test_project_routes.py
+++ b/tests/unit/api/routes/test_project_routes.py
@@ -13,16 +13,23 @@ from vdoc.exceptions import ProjectVersionNotFound
 from vdoc.models.project import Project
 
 
-@patch.dict(os.environ, {"VDOC_PROJECT_DISPLAY_NAME_MAPPING": '{"dummy-project-01": "Dummy Project 01"}'})
+@patch.dict(
+    os.environ,
+    {
+        "VDOC_PROJECT_DISPLAY_NAME_MAPPING": '{"dummy-project-01": "Dummy Project 01"}',
+        "VDOC_PROJECT_CATEGORIES": '[{"id": 1, "name": "General"}]',
+        "VDOC_PROJECT_CATEGORY_MAPPING": '{"dummy-project-01": "General"}',
+    },
+)
 @patch("vdoc.api.routes.projects.list_projects_impl")
 def test_list_projects_route(list_projects_impl_mock: MagicMock, dummy_projects_dir: Path, api: TestClient) -> None:
     mocked_projects = Project.list(search_path=dummy_projects_dir)
     list_projects_impl_mock.return_value = mocked_projects
     response = api.get("/api/projects/")
     assert response.json() == [
-        {"name": "dummy-project-01", "display_name": "Dummy Project 01"},
-        {"name": "dummy-project-02", "display_name": "dummy-project-02"},
-        {"name": "dummy-project-03", "display_name": "dummy-project-03"},
+        {"name": "dummy-project-01", "display_name": "Dummy Project 01", "category_id": 1},
+        {"name": "dummy-project-02", "display_name": "dummy-project-02", "category_id": None},
+        {"name": "dummy-project-03", "display_name": "dummy-project-03", "category_id": None},
     ]
     list_projects_impl_mock.assert_called_once_with()
 

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -18,6 +18,18 @@ def test_project_display_name(dummy_projects_dir: Path) -> None:  # pylint: disa
     assert Project(name="dummy-project-02").display_name == "dummy-project-02"
 
 
+@patch.dict(
+    os.environ,
+    {
+        "VDOC_PROJECT_CATEGORIES": '[{"id": 1, "name": "General"}, {"id": 2, "name": "API"}]',
+        "VDOC_PROJECT_CATEGORY_MAPPING": '{"dummy-project-01": "API"}',
+    },
+)
+def test_project_category(dummy_projects_dir: Path) -> None:  # pylint: disable=unused-argument
+    assert Project(name="dummy-project-01").category_id == 2
+    assert Project(name="dummy-project-02").category_id is None
+
+
 def test_list_projects(dummy_projects_dir: Path) -> None:  # pylint: disable=unused-argument
     projects = Project.list()
     assert projects == [Project(name=project_name) for project_name in DUMMY_DOCS_STRUCTURE]

--- a/tests/unit/settings/test_settings.py
+++ b/tests/unit/settings/test_settings.py
@@ -1,12 +1,17 @@
 """Contains all settings tests."""
 
 import os
+import re
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
+from vdoc.models.project_category import ProjectCategory
 from vdoc.settings import VDocSettings
 
 
+@patch.dict(os.environ, clear=True)
 def test_vdoc_settings() -> None:
     settings = VDocSettings()
     assert settings.docs_dir == Path("/srv/vdoc/docs/")
@@ -16,3 +21,41 @@ def test_vdoc_settings() -> None:
 def test_vdoc_settings_patchable() -> None:
     settings = VDocSettings()
     assert settings.docs_dir == Path("/tmp/foo/")
+
+
+@patch.dict(
+    os.environ,
+    {
+        "VDOC_PROJECT_CATEGORIES": '[{"id": 1, "name": "General"}, {"id": 2, "name": "API"}]',
+        "VDOC_PROJECT_CATEGORY_MAPPING": '{"dummy-project-01": "API"}',
+    },
+)
+def test_vdoc_settings_model_validation_project_categories() -> None:
+    settings = VDocSettings()
+    assert settings.project_categories == [ProjectCategory(id=1, name="General"), ProjectCategory(id=2, name="API")]
+    assert settings.project_category_mapping == {"dummy-project-01": "API"}
+
+
+def test_vdoc_settings_model_validation_project_categories_duplicate_name() -> None:
+    with pytest.raises(ValueError, match=re.escape("Duplicate category names are not allowed in `project_categories`")):
+        VDocSettings(project_categories=[ProjectCategory(id=1, name="General"), ProjectCategory(id=2, name="General")])
+
+
+def test_vdoc_settings_model_validation_project_categories_duplicate_id() -> None:
+    with pytest.raises(ValueError, match=re.escape("Duplicate category IDs are not allowed in `project_categories`")):
+        VDocSettings(project_categories=[ProjectCategory(id=1, name="General"), ProjectCategory(id=1, name="API")])
+
+
+@patch.dict(
+    os.environ,
+    {
+        "VDOC_PROJECT_CATEGORIES": '[{"id": 1, "name": "General"}]',
+        "VDOC_PROJECT_CATEGORY_MAPPING": '{"dummy-project-01": "Dummy"}',
+    },
+)
+def test_vdoc_settings_model_validation_project_categories_invalid_mapping() -> None:
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Category name 'Dummy' in `project_category_mapping` is not defined in `project_categories`"),
+    ):
+        VDocSettings()


### PR DESCRIPTION
**Configurable project categories**

![image](https://github.com/user-attachments/assets/33f914dd-e596-4fa0-9daa-fb7baf6e0e28)

**Usage**
Add the option to group projects by categories by setting the environment variables

- `VDOC_PROJECT_CATEGORIES`
- `VDOC_PROJECT_CATEGORY_MAPPING`

e.g.

```bash
export VDOC_PROJECT_CATEGORIES='[{"id": "0", "name": "General"}]'
export VDOC_PROJECT_CATEGORY_MAPPING='{"dummy-project-01": "General"}'
```

> [!IMPORTANT]
> - Category names and IDs must be unique.
> - Category names defined in ``VDOC_PROJECT_CATEGORY_MAPPING`` must match those configured in `VDOC_PROJECT_CATEGORIES`
> - Uncategorized projects are displayed as `MISC` 

