### PR TITLE
fix(ui): Sort categories by their ID in ascending order, `null` at the end

### DIFF
--- a/src/ui/__tests__/helpers/projectHelpers.test.ts
+++ b/src/ui/__tests__/helpers/projectHelpers.test.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect } from 'vitest'
+import { groupProjectsByCategories } from '../../helpers/Projects'
+import { Project, ProjectCategory } from '../../interfacesAndTypes/Project'
+
+describe('groupProjectsByCategories', () => {
+  const baseProjects: Project[] = [
+    { name: 'Project A', display_name: 'Proj A', category_id: 1 },
+    { name: 'Project B', display_name: 'Proj B', category_id: 2 },
+    { name: 'Project C', display_name: 'Proj C', category_id: null },
+    { name: 'Project D', display_name: 'Proj D', category_id: 1 },
+  ]
+
+  const baseCategories: ProjectCategory[] = [
+    { id: 1, name: 'Category 1' },
+    { id: 2, name: 'Category 2' },
+  ]
+
+  test('should group projects correctly by category', () => {
+    const result = groupProjectsByCategories(baseProjects, baseCategories)
+
+    expect(result).toEqual({
+      'Category 1': [baseProjects[0], baseProjects[3]],
+      'Category 2': [baseProjects[1]],
+      Misc: [baseProjects[2]],
+    })
+  })
+
+  test('should return an empty object if there are no projects', () => {
+    const result = groupProjectsByCategories([], baseCategories)
+    expect(result).toEqual({})
+  })
+
+  test('should return only categories that contain projects', () => {
+    const result = groupProjectsByCategories([baseProjects[0]], baseCategories)
+
+    expect(result).toEqual({ 'Category 1': [baseProjects[0]] })
+  })
+
+  test("should return projects sorted by category_id, with 'Misc' at the end", () => {
+    const result = Object.keys(groupProjectsByCategories(baseProjects, baseCategories))
+    expect(result).toEqual(['Category 1', 'Category 2', 'Misc'])
+  })
+
+  test('should correctly handle additional categories and projects dynamically', () => {
+    const extraProjects: Project[] = [
+      { name: 'Project E', display_name: 'Proj E', category_id: 3 },
+      { name: 'Project F', display_name: 'Proj F', category_id: null },
+    ]
+
+    const extraCategories: ProjectCategory[] = [...baseCategories, { id: 3, name: 'Category 3' }]
+
+    const result = groupProjectsByCategories([...baseProjects, ...extraProjects], extraCategories)
+
+    expect(result).toEqual({
+      'Category 1': [baseProjects[0], baseProjects[3]],
+      'Category 2': [baseProjects[1]],
+      'Category 3': [extraProjects[0]],
+      Misc: [baseProjects[2], extraProjects[1]],
+    })
+
+    expect(Object.keys(result)).toEqual(['Category 1', 'Category 2', 'Category 3', 'Misc'])
+  })
+})

--- a/src/ui/helpers/Projects.ts
+++ b/src/ui/helpers/Projects.ts
@@ -5,7 +5,11 @@ export function groupProjectsByCategories(
   projectCategories: ProjectCategory[]
 ): Record<string, Project[]> {
   const grouped: Record<string, Project[]> = {}
-  const categoriesCopy = [...projectCategories, { id: null, name: 'Misc' }]
+  const categoriesCopy = [...projectCategories, { id: null, name: 'Misc' }].sort((a, b) => {
+    if (a.id === null) return 1
+    if (b.id === null) return -1
+    return a.id - b.id
+  })
 
   categoriesCopy.forEach((category) => {
     const filteredProjects = projects.filter((project) => project.category_id === category.id)

--- a/src/ui/interfacesAndTypes/Project.ts
+++ b/src/ui/interfacesAndTypes/Project.ts
@@ -1,7 +1,7 @@
 export interface Project {
   name: string
   display_name: string
-  category_id: number
+  category_id: number | null
 }
 
 export interface ProjectCategory {

--- a/src/ui/routes/index.lazy.tsx
+++ b/src/ui/routes/index.lazy.tsx
@@ -18,35 +18,33 @@ function Index() {
   }, [projects, projectCategories])
   return (
     <Container sx={{ mt: 2 }}>
-      {Object.entries(getGroupedProjects)
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([category, projects]) => (
-          <Box key={category} sx={{ mb: 4 }} data-testid={testIDs.landingPage.projectCategories.projectCategory.main}>
-            <Typography
-              variant="h6"
-              sx={{ mb: 2, textTransform: 'uppercase' }}
-              data-testid={testIDs.landingPage.projectCategories.projectCategory.title}
+      {Object.entries(getGroupedProjects).map(([category, projects]) => (
+        <Box key={category} sx={{ mb: 4 }} data-testid={testIDs.landingPage.projectCategories.projectCategory.main}>
+          <Typography
+            variant="h6"
+            sx={{ mb: 2, textTransform: 'uppercase' }}
+            data-testid={testIDs.landingPage.projectCategories.projectCategory.title}
+          >
+            {category}
+          </Typography>
+          <Box sx={{ flexGrow: 1 }}>
+            <Grid2
+              container
+              direction="row"
+              sx={{
+                justifyContent: 'flex-start',
+                alignItems: 'center',
+              }}
+              spacing={2}
+              data-testid={testIDs.landingPage.projectCategories.projectCategory.projects.main}
             >
-              {category}
-            </Typography>
-            <Box sx={{ flexGrow: 1 }}>
-              <Grid2
-                container
-                direction="row"
-                sx={{
-                  justifyContent: 'flex-start',
-                  alignItems: 'center',
-                }}
-                spacing={2}
-                data-testid={testIDs.landingPage.projectCategories.projectCategory.projects.main}
-              >
-                {projects.map((project) => (
-                  <IndexProjectCard project={project} />
-                ))}
-              </Grid2>
-            </Box>
+              {projects.map((project) => (
+                <IndexProjectCard project={project} />
+              ))}
+            </Grid2>
           </Box>
-        ))}
+        </Box>
+      ))}
     </Container>
   )
 }

--- a/tests/ui/base.ts
+++ b/tests/ui/base.ts
@@ -44,7 +44,10 @@ export const mockAPIRequests = async (page: Page) => {
     {
       pattern: '*/**/api/project_categories/',
       response: {
-        json: [{ id: 0, name: 'General' }],
+        json: [
+          { id: 0, name: 'General' },
+          { id: 1, name: 'Extensions' },
+        ],
       },
     },
     {
@@ -52,7 +55,7 @@ export const mockAPIRequests = async (page: Page) => {
       response: {
         json: [
           { name: 'example-project-01', display_name: 'Example Project 01', category_id: 0 },
-          { name: 'example-project-02', display_name: 'example-project-02', category_id: null },
+          { name: 'example-project-02', display_name: 'example-project-02', category_id: 1 },
           { name: 'example-project-03', display_name: 'example-project-03', category_id: null },
         ],
       },

--- a/tests/ui/testIndexPage.spec.ts
+++ b/tests/ui/testIndexPage.spec.ts
@@ -11,7 +11,8 @@ test('Test navigation index to documentation to version overview', async ({ page
   await assertIndexPage(page, {
     categories: {
       General: [{ name: 'example-project-01', display_name: 'Example Project 01', category_id: 0 }],
-      Misc: [{ name: 'example-project-02', display_name: 'example-project-02', category_id: -1 }],
+      Extensions: [{ name: 'example-project-02', display_name: 'example-project-02', category_id: 1 }],
+      Misc: [{ name: 'example-project-03', display_name: 'example-project-03', category_id: null }],
     },
   })
 


### PR DESCRIPTION
So that the `MISC` category is at the end.