### PR TITLE
fix(ui): Properly handle page/history state in documentation iframe

### DIFF
--- a/src/ui/components/IFrame.tsx
+++ b/src/ui/components/IFrame.tsx
@@ -1,0 +1,162 @@
+/**
+ * This file is adapted from [docat] (https://github.com/docat-org/docat)
+ * Licensed under the MIT License.
+ */
+
+import { testIDs } from '../interfacesAndTypes/testIDs'
+import { useColorScheme } from '@mui/material'
+import { useRef, useEffect, useCallback, useState } from 'react'
+
+interface Props {
+  src: string
+  onPageChanged: (page: string, hash: string, title?: string) => void
+  onHashChanged: (hash: string) => void
+  onTitleChanged: (title: string) => void
+  onNotFound: () => void
+}
+
+export default function IFrame({ src, onPageChanged, onHashChanged, onTitleChanged, onNotFound }: Props) {
+  const { colorScheme } = useColorScheme()
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const sourceRef = useRef<string | undefined>(null)
+  const [contentWindow, setContentWindow] = useState<Window | null>()
+  const stripPrefix = '/static/projects/'
+
+  const setDarkMode = useCallback((mode: 'dark' | 'light') => {
+    iframeRef?.current?.contentWindow?.localStorage.setItem('darkMode', mode as 'light' | 'dark')
+    if (mode === 'dark') {
+      iframeRef?.current?.contentDocument?.documentElement?.classList.toggle('dark', true)
+    } else {
+      iframeRef?.current?.contentDocument?.documentElement?.classList.toggle('dark', false)
+    }
+  }, [])
+
+  // Update documentation's theme
+  useEffect(() => {
+    setDarkMode(colorScheme as 'light' | 'dark')
+  }, [colorScheme, setDarkMode])
+
+  const onIframeLoad = (): void => {
+    if (iframeRef.current === null) {
+      console.error('iframeRef is null')
+      return
+    }
+
+    // Cache current active content windows for other processes
+    setContentWindow(iframeRef.current?.contentWindow)
+
+    // Apply dark mode
+    setDarkMode(colorScheme as 'light' | 'dark')
+
+    const url = iframeRef.current?.contentDocument?.location.href
+    if (url == null) {
+      console.warn('IFrame onload event triggered, but url is null')
+      return
+    }
+
+    // React to page 404ing
+    if (iframeRef.current.contentDocument?.body.innerText === '{"detail":"Not Found"}') {
+      onNotFound()
+    }
+
+    // Make all external links in iframe open in new tab and make internal links replace the iframe url so that change
+    // doesn't show up in the page history (we'd need to click back twice)
+    iframeRef.current.contentDocument?.querySelectorAll('a').forEach((anchor: HTMLAnchorElement) => {
+      if (!anchor.href.startsWith(window.location.origin)) {
+        anchor.setAttribute('target', '_blank')
+        return
+      }
+
+      const href = anchor.getAttribute('href') ?? ''
+      if (href.trim() === '') {
+        // Ignore empty links, may be handled with js internally.
+        // Will inevitably cause the user to have to click back multiple times to get back to the previous page.
+        return
+      }
+
+      // Backup original href for onclick event
+      const originalLink = anchor.href
+      // Strip iframe prefix from the href for display/copy events
+      anchor.href = new URL(anchor.href, iframeRef.current?.contentDocument?.baseURI).href.replace(stripPrefix, '/')
+      // From here: https://www.ozzu.com/questions/358584/how-do-you-ignore-iframes-javascript-history
+      anchor.onclick = () => {
+        iframeRef.current?.contentWindow?.location.replace(originalLink)
+        sourceRef.current = originalLink
+        return false
+      }
+    })
+
+    const parts = url.split(stripPrefix).slice(1).join(stripPrefix).split('/')
+    const urlPageAndHash = parts.slice(2).join('/')
+    const hashIndex = urlPageAndHash.includes('#') ? urlPageAndHash.indexOf('#') : urlPageAndHash.length
+    const urlPage = urlPageAndHash.slice(0, hashIndex)
+    const urlHash = urlPageAndHash.slice(hashIndex)
+    const title = iframeRef.current?.contentDocument?.title
+    onPageChanged(urlPage, urlHash, title)
+  }
+
+  const hashChangeEventListener = useCallback((): void => {
+    if (iframeRef.current === null) {
+      console.error('hashChangeEvent from iframe but iframeRef is null')
+      return
+    }
+
+    const url = iframeRef.current?.contentDocument?.location.href
+    if (url == null) {
+      return
+    }
+
+    let hash = url.split('#')[1]
+    if (hash === null) {
+      hash = ''
+    }
+
+    onHashChanged(hash)
+  }, [onHashChanged])
+
+  const titleChangeEventListener = useCallback((): void => {
+    if (iframeRef.current === null) {
+      console.error('titleChangeEvent from iframe but iframeRef is null')
+      return
+    }
+
+    const title = iframeRef.current?.contentDocument?.title
+    if (title == null) {
+      return
+    }
+
+    onTitleChanged(title)
+  }, [onTitleChanged])
+
+  useEffect(() => {
+    if (!contentWindow) {
+      return
+    }
+
+    contentWindow.addEventListener('hashchange', hashChangeEventListener)
+    contentWindow.addEventListener('titlechange', titleChangeEventListener)
+
+    return () => {
+      contentWindow.removeEventListener('hashchange', hashChangeEventListener)
+      contentWindow.removeEventListener('titlechange', titleChangeEventListener)
+    }
+  }, [contentWindow, titleChangeEventListener, hashChangeEventListener])
+
+  useEffect(() => {
+    const srcWithOrigin = `${window.location.origin}${src}`
+    if (sourceRef.current !== srcWithOrigin) {
+      iframeRef.current?.contentWindow?.location.replace(srcWithOrigin)
+      sourceRef.current = srcWithOrigin
+    }
+  }, [src])
+
+  return (
+    <iframe
+      ref={iframeRef}
+      data-testid={testIDs.project.documentation.documentationIframe}
+      style={{ border: 0, width: '100%', height: '100%' }}
+      title="docs"
+      onLoad={onIframeLoad}
+    />
+  )
+}

--- a/src/ui/routes/index.lazy.tsx
+++ b/src/ui/routes/index.lazy.tsx
@@ -39,7 +39,7 @@ function Index() {
               data-testid={testIDs.landingPage.projectCategories.projectCategory.projects.main}
             >
               {projects.map((project) => (
-                <IndexProjectCard project={project} />
+                <IndexProjectCard key={project.name} project={project} />
               ))}
             </Grid>
           </Box>
@@ -51,7 +51,7 @@ function Index() {
 
 function IndexProjectCard({ project }: { project: Project }) {
   return (
-    <Grid key={project.name} size={{ xs: 6, md: 4, lg: 3 }}>
+    <Grid size={{ xs: 6, md: 4, lg: 3 }}>
       <Card
         sx={{ minHeight: 120 }}
         data-testid={testIDs.landingPage.projectCategories.projectCategory.projects.projectCard.main}

--- a/tests/ui/resources/mockedExamples.html
+++ b/tests/ui/resources/mockedExamples.html
@@ -1,14 +1,17 @@
 <html>
   <head>
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
     <link rel="stylesheet" type="text/css" href="style.css" />
   </head>
   <body>
-    <h1>This is a mocked examples page</h1>
-    <ul>
-      <li>Example 01</li>
-      <li>Example 02</li>
-      <li>Example 03</li>
-      <li><a href="index.html">Take me back to 'index.html'</a></li>
-    </ul>
+    <div class="container mx-auto">
+      <h1 class="text-3xl">This is a mocked examples page</h1>
+      <ul role="list" class="divide-y divide-gray-100">
+        <li class="flex justify-between py-5">Example 01</li>
+        <li class="flex justify-between py-5">Example 02</li>
+        <li class="flex justify-between py-5">Example 03</li>
+        <li class="flex justify-between py-5"><a href="index.html">Take me back to 'index.html'</a></li>
+      </ul>
+    </div>
   </body>
 </html>

--- a/tests/ui/resources/mockedIndex.html
+++ b/tests/ui/resources/mockedIndex.html
@@ -1,20 +1,19 @@
-<html>
+<html class="dark">
   <head>
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
     <link rel="stylesheet" type="text/css" href="style.css" />
   </head>
   <body>
-    <h1>Hello, this is a mocked documentation component.</h1>
-    <ul>
-      <li><a href="#">Link with href '#'</a></li>
-      <li><a href="index.html">Link with href 'index.html'</a></li>
-      <li><a href="examples.html">Link with href 'examples.html'</a></li>
-      <li><a href="https://www.sphinx-doc.org/">Link with href 'https://www.sphinx-doc.org/'</a></li>
-    </ul>
-    <script>
-      function applyColorMode() {
-        document.body.className = localStorage.getItem('darkMode') || 'light'
-      }
-      applyColorMode()
-    </script>
+    <div class="container mx-auto">
+      <h1 class="text-3xl">Hello, this is a mocked documentation component.</h1>
+      <ul role="list" class="divide-y divide-gray-100">
+        <li class="flex justify-between py-5"><a href="#"> Link with href '#'</a></li>
+        <li class="flex justify-between py-5"><a href="index.html">Link with href 'index.html'</a></li>
+        <li class="flex justify-between py-5"><a href="examples.html">Link with href 'examples.html'</a></li>
+        <li class="flex justify-between py-5">
+          <a href="https://www.sphinx-doc.org/">Link with href 'https://www.sphinx-doc.org/'</a>
+        </li>
+      </ul>
+    </div>
   </body>
 </html>

--- a/tests/ui/resources/style.css
+++ b/tests/ui/resources/style.css
@@ -1,13 +1,17 @@
-.light {
+/**
+ * Stylesheet that mocks the behavior of https: //sphinxawesome.xyz/.
+ */
+
+body {
   background-color: rgb(227, 242, 253);
   color: black;
 }
 
-.light a {
+a {
   color: blue;
 }
 
-.dark {
+.dark body {
   background-color: rgb(18, 18, 18);
   color: white;
 }

--- a/tests/ui/testLinkSubstitution.spec.ts
+++ b/tests/ui/testLinkSubstitution.spec.ts
@@ -10,7 +10,7 @@ test('Test link substitution', async ({ page }) => {
   // Expect the documentation iframe to display the mocked documentation page
   await expect(documentation).toContainText('Hello, this is a mocked documentation component.')
 
-  const baseUrl = 'http://localhost:3000/example-project-01/latest'
+  const baseUrl = 'http://localhost:3000/example-project-01/3.2.0'
 
   // Ensure that all links have been substituted correctly
   let linkLocators = await assertLinksOnPage(documentation, [


### PR DESCRIPTION
- Refactored the iframe into a standalone component
- Changes in the documentation route to ensure page/history state of
  documentation is correct
- Adapted E2E tests to let mocked documentation use `tailwindcss` in order
  to mimic the style behavior of https://sphinxawesome.xyz/
 