### PR TITLE
fix(api): Return the raw string representation in project version list

### DIFF
--- a/src/vdoc/methods/api/projects.py
+++ b/src/vdoc/methods/api/projects.py
@@ -32,7 +32,7 @@ def list_project_versions_impl(name: str) -> list[str]:
     Returns:
         A list of all available versions of the project.
     """
-    return [str(version) for version in Project(name=name).versions]
+    return list(Project(name=name).versions.values())
 
 
 def get_project_version_impl(name: str, version: str) -> str:

--- a/tests/unit/api/routes/test_project_category_routes.py
+++ b/tests/unit/api/routes/test_project_category_routes.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from fastapi.testclient import TestClient
 
 
-@patch.dict(os.environ, {"VDOC_PROJECT_CATEGORIES": '[{"id": 1, "name": "General"}]'})
+@patch.dict(os.environ, {"VDOC_PROJECT_CATEGORIES": '[{"id": 1, "name": "General"}]'}, clear=True)
 def test_list_project_categories_route(api: TestClient) -> None:
     response = api.get("/api/project_categories/")
     assert response.json() == [{"name": "General", "id": 1}]

--- a/tests/unit/api/routes/test_settings_routes.py
+++ b/tests/unit/api/routes/test_settings_routes.py
@@ -8,7 +8,7 @@ from fastapi.testclient import TestClient
 from vdoc.constants import DEFAULT_LOGO_DARK_URL, DEFAULT_LOGO_LIGHT_URL
 
 
-@patch.dict(os.environ, {"VDOC_LOGO_LIGHT_URL": "FOO", "VDOC_LOGO_DARK_URL": "BAR"})
+@patch.dict(os.environ, {"VDOC_LOGO_LIGHT_URL": "FOO", "VDOC_LOGO_DARK_URL": "BAR"}, clear=True)
 def test_get_logo_urls(api: TestClient) -> None:
     assert api.get("/api/settings/logo_url/light").json() == "FOO"
     assert api.get("/api/settings/logo_url/dark").json() == "BAR"

--- a/tests/unit/cli/test_run_cli.py
+++ b/tests/unit/cli/test_run_cli.py
@@ -15,7 +15,7 @@ def test_cli_warns_about_default_credentials(_: MagicMock, cli_runner: CliRunner
     assert "The application is running using the default credentials" in result.stdout
 
 
-@patch.dict(os.environ, {"VDOC_API_PASSWORD": "updated"})
+@patch.dict(os.environ, {"VDOC_API_PASSWORD": "updated"}, clear=True)
 @patch("vdoc.cli.run.run_impl")
 def test_cli_doesnt_warn_about_updated_credentials(_: MagicMock, cli_runner: CliRunner) -> None:
     result = cli_runner.invoke(app=app, args=["run"])

--- a/tests/unit/methods/api/test_project_methods.py
+++ b/tests/unit/methods/api/test_project_methods.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from vdoc.methods.api.projects import get_project_version_impl
+from vdoc.methods.api.projects import get_project_version_impl, list_project_versions_impl
 
 
 @pytest.mark.parametrize(
@@ -18,3 +18,7 @@ def test_get_project_version_impl(
     expected_version: str,
 ) -> None:
     assert get_project_version_impl(project_name, requested_version) == expected_version
+
+
+def test_list_project_versions_impl(dummy_projects_dir: Path) -> None:  # pylint: disable=unused-argument
+    assert list_project_versions_impl("dummy-project-03") == ["1.0.0", "1.3.0", "2.0.0-beta"]

--- a/tests/unit/settings/test_settings.py
+++ b/tests/unit/settings/test_settings.py
@@ -17,7 +17,7 @@ def test_vdoc_settings() -> None:
     assert settings.docs_dir == Path("/srv/vdoc/docs/")
 
 
-@patch.dict(os.environ, {"VDOC_DOCS_DIR": "/tmp/foo"})
+@patch.dict(os.environ, {"VDOC_DOCS_DIR": "/tmp/foo"}, clear=True)
 def test_vdoc_settings_patchable() -> None:
     settings = VDocSettings()
     assert settings.docs_dir == Path("/tmp/foo/")
@@ -29,6 +29,7 @@ def test_vdoc_settings_patchable() -> None:
         "VDOC_PROJECT_CATEGORIES": '[{"id": 1, "name": "General"}, {"id": 2, "name": "API"}]',
         "VDOC_PROJECT_CATEGORY_MAPPING": '{"dummy-project-01": "API"}',
     },
+    clear=True,
 )
 def test_vdoc_settings_model_validation_project_categories() -> None:
     settings = VDocSettings()
@@ -52,6 +53,7 @@ def test_vdoc_settings_model_validation_project_categories_duplicate_id() -> Non
         "VDOC_PROJECT_CATEGORIES": '[{"id": 1, "name": "General"}]',
         "VDOC_PROJECT_CATEGORY_MAPPING": '{"dummy-project-01": "Dummy"}',
     },
+    clear=True,
 )
 def test_vdoc_settings_model_validation_project_categories_invalid_mapping() -> None:
     with pytest.raises(


### PR DESCRIPTION
The `packaging.version.Version` parser shortens SemVer compatible alpha/...
tags from `X.Y.Z-beta` to `X.Y.Zb0` and doesn't keep a reference to the
original raw string. The `list_project_versions_impl` function returned
the list of parsed versions (keys) of the dictionary and not the raw
versions (values).

This fixes the deviation between displayed version and list of available versions in the version selection dropdown:

![2025-04-07_141436](https://github.com/user-attachments/assets/bb8071f7-41d6-4813-944c-7eb718b002e3)
