### PR TITLE
fix(ui): Open links in new tabs if they have a `_blank` target

### DIFF
--- a/src/ui/components/IFrame.tsx
+++ b/src/ui/components/IFrame.tsx
@@ -78,6 +78,12 @@ export default function IFrame({ src, onPageChanged, onHashChanged, onTitleChang
       const originalLink = anchor.href
       // Strip iframe prefix from the href for display/copy events
       anchor.href = new URL(anchor.href, iframeRef.current?.contentDocument?.baseURI).href.replace(stripPrefix, '/')
+
+      // Links that are to be opened in new tabs should still be opened in new tabs
+      if (anchor.target === '_blank') {
+        return
+      }
+
       // From here: https://www.ozzu.com/questions/358584/how-do-you-ignore-iframes-javascript-history
       anchor.onclick = () => {
         iframeRef.current?.contentWindow?.location.replace(originalLink)

--- a/tests/ui/helpers.ts
+++ b/tests/ui/helpers.ts
@@ -24,6 +24,42 @@ export const assertLinksOnPage = async (locator: Locator, links: string[]): Prom
 }
 
 /**
+ * Asserts that clicking a link opens a new tab (popup page).
+ *
+ * @param page The playwright page object.
+ * @param linkLocator The link locator to click.
+ * @param expectedUrl The expected URL in the new tab.
+ * @param options Optional settings for validation.
+ * @param options.timeout Optional timeout for popup detection.
+ *
+ * @returns The new tab.
+ */
+export async function assertLinkOpensInNewTab(
+  page: Page,
+  linkSelector: Locator,
+  expectedUrl: string,
+  options?: {
+    timeout?: number
+  }
+): Promise<Page> {
+  const { timeout } = options ?? {}
+
+  const originalUrl = page.url()
+
+  // Wait for a new page (popup) to open after clicking the link
+  const [newPage] = await Promise.all([page.waitForEvent('popup', { timeout }), linkSelector.click()])
+
+  // Wait for the new tab to load
+  await newPage.waitForLoadState('load')
+
+  expect(newPage.url()).toBe(expectedUrl)
+
+  expect(page.url()).toBe(originalUrl)
+
+  return newPage
+}
+
+/**
  * Expects the version dropdown to be visible and to contain the expected versions.
  *
  * @param page The playwright page object.

--- a/tests/ui/resources/mockedIndex.html
+++ b/tests/ui/resources/mockedIndex.html
@@ -13,6 +13,9 @@
         <li class="flex justify-between py-5">
           <a href="https://www.sphinx-doc.org/">Link with href 'https://www.sphinx-doc.org/'</a>
         </li>
+        <li class="flex justify-between py-5">
+          <a href="https://example.com/" target="_blank">Link to 'https://example.com/' that opens in a new tab</a>
+        </li>
       </ul>
     </div>
   </body>

--- a/tests/ui/testLinkSubstitution.spec.ts
+++ b/tests/ui/testLinkSubstitution.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 import test, { prepareTestSuite } from './base'
-import { openProjectDocumentation, assertLinksOnPage, BASE_URL } from './helpers'
+import { openProjectDocumentation, assertLinksOnPage, assertLinkOpensInNewTab, BASE_URL } from './helpers'
 
 await prepareTestSuite(test)
 
@@ -18,7 +18,10 @@ test('Test link substitution', async ({ page }) => {
     `${baseUrl}/index.html`,
     `${baseUrl}/examples.html`,
     'https://www.sphinx-doc.org/',
+    'https://example.com/',
   ])
+
+  await (await assertLinkOpensInNewTab(page, linkLocators.last(), 'https://example.com/')).close()
 
   // Go to the examples page
   await linkLocators.nth(2).click()
@@ -34,5 +37,7 @@ test('Test link substitution', async ({ page }) => {
     `${baseUrl}/index.html`,
     `${baseUrl}/examples.html`,
     'https://www.sphinx-doc.org/',
+    'https://example.com/',
   ])
+  await (await assertLinkOpensInNewTab(page, linkLocators.last(), 'https://example.com/')).close()
 })


### PR DESCRIPTION
Links that are to be opened in new tabs (i.e. have the `_blank` target) should still be opened in new tabs.

This fixes the internal ticket [BUGS-6223](https://vorausrobotik.atlassian.net/issues/BUGS-6223)

[BUGS-6223]: https://vorausrobotik.atlassian.net/browse/BUGS-6223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ