### PR TITLE
fix(ui)!: Open links in same window or new tab

### DIFF
--- a/src/ui/__tests__/helpers/routeHelpers.test.ts
+++ b/src/ui/__tests__/helpers/routeHelpers.test.ts
@@ -8,60 +8,67 @@ describe('sanitizeDocuUri', () => {
       {
         input: {
           href: `${basePath}/project-one/6.0/index.html#`,
+        },
+        // Empty hash must be removed
+        expected: {
           projectName: 'project-one',
-          projectVersion: '6.0',
+          version: '6.0',
+          _splat: 'index.html',
+          href: `${basePath}/project-one/6.0/index.html`,
+        },
+      },
+      {
+        input: {
+          href: `project-one/6.0/index.html#id`,
         },
         expected: {
           projectName: 'project-one',
           version: '6.0',
-          _splat: 'index.html#',
-          href: `${basePath}/project-one/6.0/index.html#`,
+          _splat: 'index.html#id',
+          href: 'project-one/6.0/index.html#id',
         },
       },
       {
+        // No reminder (index.html or whatever) must work
         input: {
-          href: `${basePath}/meta-project/1.3.0/#`,
-          projectName: 'meta-project',
-          projectVersion: '1.3.0',
+          href: `${basePath}/meta-project/1.3.0/#id?test=foo`,
         },
         expected: {
           projectName: 'meta-project',
           version: '1.3.0',
-          _splat: '#',
-          href: `${basePath}/meta-project/1.3.0/#`,
+          _splat: '#id?test=foo',
+          href: `${basePath}/meta-project/1.3.0/#id?test=foo`,
         },
       },
       {
         input: {
-          href: `${basePath}/meta-project/1.3.0`,
-          projectName: 'meta-project',
-          projectVersion: '1.3.0',
+          href: `${basePath}/meta-project/1.3.0/index.html#id?foo=bar&bar=foo`,
         },
+        // Hash and search must work
         expected: {
           projectName: 'meta-project',
           version: '1.3.0',
-          _splat: '',
-          href: `${basePath}/meta-project/1.3.0`,
+          _splat: 'index.html#id?foo=bar&bar=foo',
+          href: `${basePath}/meta-project/1.3.0/index.html#id?foo=bar&bar=foo`,
         },
       },
       {
+        // Override name and version must work
         input: {
-          href: `${basePath}/project-one/latest/examples.html#examples`,
-          projectName: 'project-one',
-          projectVersion: 'latest',
+          href: `${basePath}/project-one/1.0.0/examples.html#examples`,
+          overrideVersion: 'latest',
+          overrideName: 'example',
         },
         expected: {
-          projectName: 'project-one',
+          projectName: 'example',
           version: 'latest',
           _splat: 'examples.html#examples',
-          href: `${basePath}/project-one/latest/examples.html#examples`,
+          href: `${basePath}/example/latest/examples.html#examples`,
         },
       },
       {
         input: {
           href: `${basePath}/static/projects/project-one/latest/examples.html#examples`,
-          projectName: 'project-one',
-          projectVersion: 'latest',
         },
         expected: {
           projectName: 'project-one',
@@ -72,14 +79,13 @@ describe('sanitizeDocuUri', () => {
       },
     ]
     testData.forEach(({ input, expected }) => {
-      expect(sanitizeDocuUri(input.href, basePath, input.projectName, input.projectVersion)).toStrictEqual(expected)
+      expect(sanitizeDocuUri(input.href, input.overrideName, input.overrideVersion)).toStrictEqual(expected)
     })
   })
   test('sanitizing invalid or external uris must throw errors', () => {
-    const basePath = 'http://localhost:8080'
     const testData = ['https://google.com', 'http://localhost:9000']
     testData.forEach((href) => {
-      expect(() => sanitizeDocuUri(href, basePath, '', '')).toThrowError(`Unable to sanitize doc URI ${href}`)
+      expect(() => sanitizeDocuUri(href)).toThrowError(`Unable to match URI '${href}'`)
     })
   })
 })

--- a/src/ui/components/IFrame.tsx
+++ b/src/ui/components/IFrame.tsx
@@ -48,8 +48,8 @@ export default function IFrame({ src, onPageChanged, onHashChanged, onTitleChang
     // Apply dark mode
     setDarkMode(colorScheme as 'light' | 'dark')
 
-    const url = iframeRef.current?.contentDocument?.location.href
-    if (url == null) {
+    const iframeHref = iframeRef.current?.contentDocument?.location.href
+    if (iframeHref == null) {
       console.warn('IFrame onload event triggered, but url is null')
       return
     }
@@ -92,7 +92,7 @@ export default function IFrame({ src, onPageChanged, onHashChanged, onTitleChang
       }
     })
 
-    const parts = url.split(stripPrefix).slice(1).join(stripPrefix).split('/')
+    const parts = iframeHref.split(stripPrefix).slice(1).join(stripPrefix).split('/')
     const urlPageAndHash = parts.slice(2).join('/')
     const hashIndex = urlPageAndHash.includes('#') ? urlPageAndHash.indexOf('#') : urlPageAndHash.length
     const urlPage = urlPageAndHash.slice(0, hashIndex)

--- a/tests/ui/helpers.ts
+++ b/tests/ui/helpers.ts
@@ -295,6 +295,7 @@ export const openProjectDocumentation = async (page: Page, name: string, version
   const docIframe = page.getByTestId(testIDs.project.documentation.documentationIframe)
 
   await page.goto(`/${name}/${version}`)
+  await page.waitForLoadState()
 
   await expect(page).toHaveURL(`${BASE_URL}/${name}/${version}`)
 

--- a/tests/ui/testAppName.spec.ts
+++ b/tests/ui/testAppName.spec.ts
@@ -3,5 +3,6 @@ import test from './base'
 
 test('Test App Title', async ({ page }) => {
   await page.goto('/')
+  await page.waitForLoadState()
   await expect(page).toHaveTitle('vdoc')
 })

--- a/tests/ui/testIndexPage.spec.ts
+++ b/tests/ui/testIndexPage.spec.ts
@@ -7,6 +7,7 @@ await prepareTestSuite(test)
 
 test('Test navigation index to documentation to version overview', async ({ page }) => {
   await page.goto('/')
+  await page.waitForLoadState()
 
   await assertIndexPage(page, {
     categories: {
@@ -32,6 +33,7 @@ test('Test navigation index to documentation to version overview', async ({ page
 
   // Navigate to the latest documentation of example-project-01
   await documentationButton.click()
+  await page.waitForLoadState()
   await expect(page).toHaveURL(/.*example-project-01\/latest/)
 
   // Ensure documentation is rendered in the iframe
@@ -70,6 +72,7 @@ test('Test project overview on no projects', async ({ page }) => {
 
   // Make sure no projects are listed and the error component is shown with all correct parameters
   await page.goto('/')
+  await page.waitForLoadState()
   await expect(page.getByTestId(testIDs.errorComponent.main)).toBeVisible()
   expect(await page.getByTestId(testIDs.errorComponent.title).innerText()).toBe('No projects found')
   expect(await page.getByTestId(testIDs.errorComponent.description).innerText()).toBe(

--- a/tests/ui/testLinkSubstitution.spec.ts
+++ b/tests/ui/testLinkSubstitution.spec.ts
@@ -25,11 +25,13 @@ test('Test link substitution', async ({ page }) => {
 
   // Go to the examples page
   await linkLocators.nth(2).click()
+  await page.waitForLoadState()
   await expect(page).toHaveURL(`${baseUrl}/examples.html`)
 
   linkLocators = await assertLinksOnPage(documentation, [`${baseUrl}/index.html`])
 
   await linkLocators.first().click()
+  await page.waitForLoadState()
   await expect(page).toHaveURL(`${baseUrl}/index.html`)
 
   linkLocators = await assertLinksOnPage(documentation, [

--- a/tests/ui/testNavigation.spec.ts
+++ b/tests/ui/testNavigation.spec.ts
@@ -7,6 +7,7 @@ await prepareTestSuite(test)
 test('Test navigation back to index page from index page (stay on same page)', async ({ page }) => {
   // GIVEN: The user is on the index page
   await page.goto('/')
+  await page.waitForLoadState()
   await assertIndexPage(page)
   await assertMenuBar(page, `${BASE_URL}/`)
 
@@ -15,6 +16,7 @@ test('Test navigation back to index page from index page (stay on same page)', a
 
   // THEN: The user should stay on the index page
   await assertIndexPage(page)
+  await page.waitForLoadState()
   await assertMenuBar(page, `${BASE_URL}/`)
 })
 
@@ -27,6 +29,7 @@ test('Test navigation back to index page from project documentation', async ({ p
   await page.getByTestId(testIDs.header.logo.main).click()
 
   // THEN: The user should be redirected to the index page
+  await page.waitForLoadState()
   await assertIndexPage(page)
   await assertMenuBar(page, `${BASE_URL}/`)
 })
@@ -34,6 +37,7 @@ test('Test navigation back to index page from project documentation', async ({ p
 test('Test navigation back to index page from project version overview', async ({ page }) => {
   // GIVEN: The user navigates to the version overview of a project
   await page.goto('/example-project-01')
+  await page.waitForLoadState()
   await assertVersionOverview(page, 'example-project-01', {
     v3: ['3.0.0', '3.1.0', '3.2.0'],
     v2: ['2.0.0'],
@@ -45,6 +49,7 @@ test('Test navigation back to index page from project version overview', async (
   await page.getByTestId(testIDs.header.logo.main).click()
 
   // THEN: The user should be redirected to the index page
+  await page.waitForLoadState()
   await assertIndexPage(page)
   await assertMenuBar(page, `${BASE_URL}/`)
 })

--- a/tests/ui/testProjectDocumentation.spec.ts
+++ b/tests/ui/testProjectDocumentation.spec.ts
@@ -7,8 +7,10 @@ await prepareTestSuite(test)
 
 test('Requesting non existing versions must be handled properly with automatic redirect', async ({ page }) => {
   await page.goto('/')
+  await page.waitForLoadState()
   await assertIndexPage(page)
   await page.goto('/example-project-01/42.0.0')
+  await page.waitForLoadState()
   await expect(page).toHaveURL(`${BASE_URL}/example-project-01/42.0.0`)
 
   await expect(page.getByTestId(testIDs.project.documentation.documentationIframe)).not.toBeVisible()
@@ -31,8 +33,10 @@ test('Requesting non existing versions must be handled properly with automatic r
 
 test('Requesting non existing versions must be handled properly with manual redirect', async ({ page }) => {
   await page.goto('/')
+  await page.waitForLoadState()
   await assertIndexPage(page)
   await page.goto('/example-project-01/42.0.0')
+  await page.waitForLoadState()
   await expect(page).toHaveURL(`${BASE_URL}/example-project-01/42.0.0`)
 
   await expect(page.getByTestId(testIDs.project.documentation.documentationIframe)).not.toBeVisible()
@@ -45,6 +49,7 @@ test('Requesting non existing versions must be handled properly with manual redi
   await page.getByTestId(testIDs.errorComponent.actionButton).click()
 
   // User must be redirected to previous page
+  await page.waitForLoadState()
   await assertIndexPage(page, { timeout: 1000 })
 })
 
@@ -58,8 +63,10 @@ test('Requesting invalid versions must be handled properly with manual redirect'
     })
   )
   await page.goto('/')
+  await page.waitForLoadState()
   await assertIndexPage(page)
   await page.goto('/example-project-01/invalid')
+  await page.waitForLoadState()
   await expect(page).toHaveURL(`${BASE_URL}/example-project-01/invalid`)
 
   await expect(page.getByTestId(testIDs.project.documentation.documentationIframe)).not.toBeVisible()
@@ -72,6 +79,7 @@ test('Requesting invalid versions must be handled properly with manual redirect'
   await page.getByTestId(testIDs.errorComponent.actionButton).click()
 
   // User must be redirected to previous page
+  await page.waitForLoadState()
   await assertIndexPage(page, { timeout: 1000 })
 })
 
@@ -85,8 +93,10 @@ test('Requesting non existing project must be handled properly', async ({ page }
     })
   )
   await page.goto('/')
+  await page.waitForLoadState()
   await assertIndexPage(page)
   await page.goto('/non-existing-project')
+  await page.waitForLoadState()
   await expect(page).toHaveURL(`${BASE_URL}/non-existing-project`)
 
   await expect(page.getByTestId(testIDs.project.documentation.documentationIframe)).not.toBeVisible()
@@ -99,6 +109,7 @@ test('Requesting non existing project must be handled properly', async ({ page }
   await page.getByTestId(testIDs.errorComponent.actionButton).click()
 
   // User must be redirected to previous page
+  await page.waitForLoadState()
   await assertIndexPage(page, { timeout: 1000 })
 })
 
@@ -113,8 +124,10 @@ test('Requesting non existing version must be handled properly', async ({ page }
     })
   )
   await page.goto('/')
+  await page.waitForLoadState()
   await assertIndexPage(page)
   await page.goto('/example-project-01/1')
+  await page.waitForLoadState()
   await expect(page).toHaveURL(`${BASE_URL}/example-project-01/1`)
 
   await expect(page.getByTestId(testIDs.project.documentation.documentationIframe)).not.toBeVisible()
@@ -126,13 +139,16 @@ test('Requesting non existing version must be handled properly', async ({ page }
   await page.getByTestId(testIDs.errorComponent.actionButton).click()
 
   // User must be redirected to previous page
+  await page.waitForLoadState()
   await assertIndexPage(page, { timeout: 1000 })
 })
 
 test('Requesting non existing documentation page must be handled properly', async ({ page }) => {
   await page.goto('/')
+  await page.waitForLoadState()
   await assertIndexPage(page)
   await page.goto('/example-project-03/1.0.0/nonexisting.html')
+  await page.waitForLoadState()
   await expect(page).toHaveURL(`${BASE_URL}/example-project-03/1.0.0/nonexisting.html`)
 
   await expect(page.getByTestId(testIDs.project.documentation.documentationIframe)).not.toBeVisible()
@@ -144,5 +160,6 @@ test('Requesting non existing documentation page must be handled properly', asyn
   await page.getByTestId(testIDs.errorComponent.actionButton).click()
 
   // User must be redirected to previous page
+  await page.waitForLoadState()
   await assertIndexPage(page, { timeout: 1000 })
 })

--- a/tests/ui/testToggleColorMode.spec.ts
+++ b/tests/ui/testToggleColorMode.spec.ts
@@ -8,24 +8,28 @@ test.describe('Color schemes tests', () => {
   test('Color mode should be system by default', async ({ page }) => {
     await page.emulateMedia({ colorScheme: undefined })
     await page.goto('/example-project-01/latest')
+    await page.waitForLoadState()
     await assertCurrentColorModeButton(page, 'system')
   })
 
   test('Theme should be light if preferred color scheme is undefined', async ({ page }) => {
     await page.emulateMedia({ colorScheme: undefined })
     await page.goto('/example-project-01/latest')
+    await page.waitForLoadState()
     await assertTheme(page, 'light')
   })
 
   test('Theme should be light if preferred color scheme is "light"', async ({ page }) => {
     await page.emulateMedia({ colorScheme: 'light' })
     await page.goto('/example-project-01/latest')
+    await page.waitForLoadState()
     await assertTheme(page, 'light')
   })
 
   test('Theme should be dark if preferred color scheme is "dark"', async ({ page }) => {
     await page.emulateMedia({ colorScheme: 'dark' })
     await page.goto('/example-project-01/latest')
+    await page.waitForLoadState()
     await assertTheme(page, 'dark')
   })
 
@@ -39,6 +43,7 @@ test.describe('Color schemes tests', () => {
         }) => {
           await page.emulateMedia({ colorScheme: preferredColorScheme })
           await page.goto('/example-project-01/latest')
+          await page.waitForLoadState()
 
           // Make sure that the user preferred color scheme is applied
           await assertTheme(page, preferredColorScheme)


### PR DESCRIPTION
Open the link in a new tab when
- The origin differs.
- The link leads to a different project documentation than the one that is currently open.
- The link is already marked with a `_blank` target.

Otherwise, open the link in the same window.

> [!NOTE]
> The helper function `sanitizeDocuUri` has been reworked to be more resilient against edge cases.
Since this rework is somehow a breaking change, this PR is marked as breaking, too.
However, since this is an internal helper function which isn't used anywhere else, this is fine.

This fixes the internal bug [BUGS-6245](https://vorausrobotik.atlassian.net/browse/BUGS-6245).

[BUGS-6245]: https://vorausrobotik.atlassian.net/browse/BUGS-6245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ