### PR TITLE
refactor(api)!: Define order of included routers with a `FastAPI` lifespan

### DIFF
--- a/src/ui/helpers/APIFunctions.ts
+++ b/src/ui/helpers/APIFunctions.ts
@@ -19,7 +19,7 @@ export const fetchLogoURL = async (mode: EffectiveColorMode): Promise<string | n
 }
 
 export const fetchAppVersion = async (): Promise<string> => {
-  return (await axios.get('/api/version')).data
+  return (await axios.get('/api/version/')).data
 }
 
 export const fetchProjectCategories = async (): Promise<ProjectCategory[]> => {

--- a/src/vdoc/api/lifespan.py
+++ b/src/vdoc/api/lifespan.py
@@ -1,0 +1,104 @@
+"""Defines the FastAPI lifespan and route loading."""
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import AsyncGenerator
+
+from fastapi import FastAPI
+from fastapi.routing import Mount
+from fastapi.staticfiles import StaticFiles
+from starlette.responses import FileResponse
+
+from vdoc.api.routes import project_categories as PROJECT_CATEGORIES_MODULE
+from vdoc.api.routes import projects as PROJECTS_MODULE
+from vdoc.api.routes import settings as SETTINGS_MODULE
+from vdoc.api.routes import version as VERSION_MODULE
+from vdoc.methods.api.projects import get_project_version_impl
+from vdoc.settings import VDocSettings
+
+_PACKAGE_PATH = Path(__file__).parent.parent
+
+webapp_path = _PACKAGE_PATH / "webapp"
+docs_path = _PACKAGE_PATH / "docs"
+
+
+@asynccontextmanager
+async def routes_loader_lifespan(fastapi: FastAPI) -> AsyncGenerator[None, None]:
+    """Lifespan context manager for the FastAPI app.
+
+    The order for mounting the routers is important. The frontend router must be the last one to ensure that all
+    non-api or documentation requests are handled by the frontend.
+
+    Args:
+        fastapi: The FastAPI app instance.
+
+    Yields:
+        None: No value is yielded.
+    """
+    fastapi = _include_static_api_routers(fastapi=fastapi)
+    fastapi = _include_intersphinx_router(fastapi=fastapi)
+    fastapi = _include_static_documentation_routers(fastapi=fastapi)
+    fastapi = _include_frontend_router(fastapi=fastapi)
+    yield
+
+
+def _include_static_api_routers(fastapi: FastAPI) -> FastAPI:
+    fastapi.include_router(PROJECTS_MODULE.router, prefix="/api")
+    fastapi.include_router(SETTINGS_MODULE.router, prefix="/api")
+    fastapi.include_router(PROJECT_CATEGORIES_MODULE.router, prefix="/api")
+    fastapi.include_router(VERSION_MODULE.router, prefix="/api")
+    return fastapi
+
+
+def _include_static_documentation_routers(fastapi: FastAPI) -> FastAPI:
+    for route in [
+        Mount(
+            "/static/docs",
+            app=StaticFiles(directory=str(docs_path), html=True, check_dir=False),
+            name="vdoc-docs",
+        ),
+        Mount(
+            "/static/projects",
+            app=StaticFiles(directory=VDocSettings().docs_dir.as_posix(), html=True, check_dir=False),
+            name="projects",
+        ),
+    ]:
+        fastapi.routes.append(route)
+    return fastapi
+
+
+def _include_intersphinx_router(fastapi: FastAPI) -> FastAPI:
+    @fastapi.get("/{project_name}/{version}/objects.inv")
+    def serve_sphinx_objects_inventory(project_name: str, version: str) -> FileResponse:
+        """Serves the objects.inv sphinx file for intersphinx mappings.
+
+        Args:
+            project_name: The requested project name.
+            version: The requested project version.
+
+        Returns:
+            FileResponse: The objects.inv file.
+        """
+        served_version = get_project_version_impl(name=project_name, version=version)
+
+        return FileResponse(path=VDocSettings().docs_dir / project_name / served_version / "objects.inv")
+
+    return fastapi
+
+
+def _include_frontend_router(fastapi: FastAPI) -> FastAPI:
+    @fastapi.get("/{file_path:path}")
+    def serve_ui_and_assets(file_path: str) -> FileResponse:
+        """Serves the web UI and the static assets (JS bundles, ...) as a last fallback for all non-matched requests.
+
+        Args:
+            file_path (str): The requested file path.
+
+        Returns:
+            FileResponse: The requested asset file if existing, otherwise the index.html.
+        """
+        if (full_path := webapp_path / file_path).is_file():
+            return FileResponse(path=full_path)
+        return FileResponse(path=webapp_path / "index.html")
+
+    return fastapi

--- a/src/vdoc/api/routes/version.py
+++ b/src/vdoc/api/routes/version.py
@@ -1,0 +1,17 @@
+"""Contains the version REST API routes."""
+
+from fastapi import APIRouter
+
+from vdoc import get_app_version
+
+router = APIRouter(prefix="/version", tags=["Version"])
+
+
+@router.get("/")
+def get_app_version_route() -> str:
+    """Returns the version of the app.
+
+    Returns:
+        The app version.
+    """
+    return get_app_version()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,8 +42,9 @@ def resource_dir_fixture() -> Path:
 
 
 @pytest.fixture(scope="function", name="api")
-def api_client_fixture() -> TestClient:
-    return TestClient(app)
+def api_client_fixture() -> Generator[TestClient, None, None]:
+    with TestClient(app) as client:
+        yield client
 
 
 @pytest.fixture(scope="function", name="authenticated_api")

--- a/tests/ui/base.ts
+++ b/tests/ui/base.ts
@@ -102,7 +102,7 @@ export const mockAPIRequests = async (page: Page) => {
       response: { json: 'https://logos.vorausrobotik.com/voraus-robotik_farbig_negativ_rgb.png' },
     },
     {
-      pattern: '*/**/api/version',
+      pattern: '*/**/api/version/',
       response: { json: '42.0.42' },
     },
   ]

--- a/tests/unit/api/routes/test_misc_routes.py
+++ b/tests/unit/api/routes/test_misc_routes.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
+from pytest import MonkeyPatch
 
 
 @patch("vdoc.api.routes.version.get_app_version")
@@ -23,3 +24,19 @@ def test_sphinx_inventory(dummy_projects_dir: Path, api: TestClient) -> None:
 def test_sphinx_inventory_non_existing(api: TestClient) -> None:
     response = api.get("/dummy-project-01/latest/objects.inv")
     assert response.status_code == 404
+
+
+def test_serve_frontend_assets(monkeypatch: MonkeyPatch, tmp_path: Path, api: TestClient) -> None:
+    (tmp_path / "style.css").write_text("dummy style sheet")
+    monkeypatch.setattr("vdoc.api.lifespan.webapp_path", tmp_path)
+    response = api.get("/style.css")
+    assert response.status_code == 200
+    assert response.text == "dummy style sheet"
+
+
+def test_serve_frontend_assets_index_fallback(monkeypatch: MonkeyPatch, tmp_path: Path, api: TestClient) -> None:
+    (tmp_path / "index.html").write_text("dummy index.html content")
+    monkeypatch.setattr("vdoc.api.lifespan.webapp_path", tmp_path)
+    response = api.get("/style.css")
+    assert response.status_code == 200
+    assert response.text == "dummy index.html content"

--- a/tests/unit/api/routes/test_misc_routes.py
+++ b/tests/unit/api/routes/test_misc_routes.py
@@ -1,5 +1,6 @@
 """Contains all unit tests for misc functionalities of REST API."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
@@ -9,3 +10,16 @@ from fastapi.testclient import TestClient
 def test_api_get_app_version(get_app_version_mock: MagicMock, api: TestClient) -> None:
     get_app_version_mock.return_value = "42.0.0"
     assert api.get("/api/version/").json() == "42.0.0"
+
+
+def test_sphinx_inventory(dummy_projects_dir: Path, api: TestClient) -> None:
+    inventory_file_mock = dummy_projects_dir / "dummy-project-01" / "2.0.0" / "objects.inv"
+    inventory_file_mock.write_text("dummy objects.inv content")
+    response = api.get("/dummy-project-01/latest/objects.inv")
+    assert response.status_code == 200
+    assert response.text == "dummy objects.inv content"
+
+
+def test_sphinx_inventory_non_existing(api: TestClient) -> None:
+    response = api.get("/dummy-project-01/latest/objects.inv")
+    assert response.status_code == 404

--- a/tests/unit/api/routes/test_misc_routes.py
+++ b/tests/unit/api/routes/test_misc_routes.py
@@ -1,9 +1,11 @@
 """Contains all unit tests for misc functionalities of REST API."""
 
+from unittest.mock import MagicMock, patch
+
 from fastapi.testclient import TestClient
-from pytest import MonkeyPatch
 
 
-def test_api_get_app_version(monkeypatch: MonkeyPatch, api: TestClient) -> None:
-    monkeypatch.setattr("vdoc.__version__", "42.0.0")
-    assert api.get("/api/version").json() == "42.0.0"
+@patch("vdoc.api.routes.version.get_app_version")
+def test_api_get_app_version(get_app_version_mock: MagicMock, api: TestClient) -> None:
+    get_app_version_mock.return_value = "42.0.0"
+    assert api.get("/api/version/").json() == "42.0.0"


### PR DESCRIPTION
The loading order and definition of included routers in the API's `__init__.py` file has grown quite complex. Since the order of loaded routes is important for the API functionality and webapp integration, it is crucial to make this more maintainable.

Moreover, with this change it is no longer necessary to monkeypatch environment variables in tests for dynamic route/value patching (e.g. for the app version).

This PR aims to refactor this process in a more transparent way using FastAPI's [lifespan events](https://fastapi.tiangolo.com/advanced/events/#lifespan).

> [!WARNING]
> The API endpoint for fetching the version has changed from `/api/version` to `/api/version/` (trailing slash)
> This is the reason why this PR is marked as breaking change.