### PR TITLE
refactor(ui): Refactor `MenuBar` into separate components

### DIFF
--- a/src/ui/components/MenuBar.tsx
+++ b/src/ui/components/MenuBar.tsx
@@ -1,4 +1,4 @@
-import { Box, IconButton, AppBar, Toolbar, SelectChangeEvent, useTheme, Typography } from '@mui/material'
+import { Box, BoxProps, IconButton, AppBar, Toolbar, SelectChangeEvent, useTheme, Typography } from '@mui/material'
 import { useState, useEffect, useMemo } from 'react'
 import testIDs from '../interfacesAndTypes/testIDs'
 import ThemePluginT from '../interfacesAndTypes/plugins/ThemePlugin'
@@ -44,21 +44,17 @@ function LeftGroup() {
   )
 }
 
-export default function MenuBar() {
-  const navigate = useNavigate({ from: '/$projectName/$version/$' })
+interface RightGroupPros extends BoxProps {
+  setSidebarOpen: (open: boolean) => void
+}
+
+function RightGroup({ setSidebarOpen }: RightGroupPros) {
   const params = useParams({ strict: false })
-  const theme = useTheme()
-  const [sidebarOpen, setSidebarOpen] = useState(false)
+  const navigate = useNavigate({ from: '/$projectName/$version/$' })
 
   const [projectName, setProjectName] = useState<string | undefined>(undefined)
-  const [appVersion, setAppVersion] = useState<string | undefined>(undefined)
-
   const [projectVersions, setProjectVersions] = useState<string[] | undefined>(undefined)
   const [latestVersion, setLatestVersion] = useState<string | undefined>(undefined)
-
-  useEffect(() => {
-    fetchAppVersion().then((appVersion) => setAppVersion(appVersion))
-  }, [theme])
 
   useEffect(() => {
     const fetchData = async (name: string): Promise<[string[], string]> => {
@@ -105,6 +101,39 @@ export default function MenuBar() {
   }, [params.version, projectVersions])
 
   return (
+    <>
+      {projectVersions && latestVersion && params.version && (
+        <Box sx={{ flexGrow: 0, display: { xs: 'flex' } }}>
+          <VersionDropdown
+            selectedVersion={getSelectedVersion}
+            latestVersion={latestVersion}
+            versions={projectVersions}
+            onVersionChange={handleVersionSelectChange}
+          />
+        </Box>
+      )}
+      <IconButton
+        data-testid={testIDs.header.settingsButton}
+        aria-label="Open App Settings"
+        onClick={() => setSidebarOpen(true)}
+      >
+        <SettingsOutlinedIcon />
+      </IconButton>
+    </>
+  )
+}
+
+export default function MenuBar() {
+  const theme = useTheme()
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+
+  const [appVersion, setAppVersion] = useState<string | undefined>(undefined)
+
+  useEffect(() => {
+    fetchAppVersion().then((appVersion) => setAppVersion(appVersion))
+  }, [theme])
+
+  return (
     <AppBar
       position="static"
       data-testid={testIDs.header.main}
@@ -117,23 +146,8 @@ export default function MenuBar() {
         {/* Logo and/or Text */}
         <LeftGroup />
         <Box sx={{ flexGrow: 1, display: { xs: 'none', sm: 'flex' } }} />
-        {projectVersions && latestVersion && params.version && (
-          <Box sx={{ flexGrow: 0, display: { xs: 'flex' } }}>
-            <VersionDropdown
-              selectedVersion={getSelectedVersion}
-              latestVersion={latestVersion}
-              versions={projectVersions}
-              onVersionChange={handleVersionSelectChange}
-            />
-          </Box>
-        )}
-        <IconButton
-          data-testid={testIDs.header.settingsButton}
-          aria-label="Open App Settings"
-          onClick={() => setSidebarOpen(true)}
-        >
-          <SettingsOutlinedIcon />
-        </IconButton>
+        {/* Optional version dropdown and settings button */}
+        <RightGroup setSidebarOpen={setSidebarOpen} />
       </Toolbar>
       <SettingsSidebar open={sidebarOpen} setOpen={setSidebarOpen} appVersion={appVersion} />
     </AppBar>

--- a/src/ui/components/MenuBar.tsx
+++ b/src/ui/components/MenuBar.tsx
@@ -1,4 +1,14 @@
-import { Box, BoxProps, IconButton, AppBar, Toolbar, SelectChangeEvent, useTheme, Typography } from '@mui/material'
+import {
+  Box,
+  BoxProps,
+  Grid,
+  IconButton,
+  AppBar,
+  Toolbar,
+  SelectChangeEvent,
+  useTheme,
+  Typography,
+} from '@mui/material'
 import { useState, useEffect, useMemo } from 'react'
 import testIDs from '../interfacesAndTypes/testIDs'
 import ThemePluginT from '../interfacesAndTypes/plugins/ThemePlugin'
@@ -102,23 +112,23 @@ function RightGroup({ setSidebarOpen }: RightGroupPros) {
 
   return (
     <>
-      {projectVersions && latestVersion && params.version && (
-        <Box sx={{ flexGrow: 0, display: { xs: 'flex' } }}>
+      <Box sx={{ display: 'flex', flexDirection: 'row', justifyContent: 'right' }}>
+        {projectVersions && latestVersion && params.version && (
           <VersionDropdown
             selectedVersion={getSelectedVersion}
             latestVersion={latestVersion}
             versions={projectVersions}
             onVersionChange={handleVersionSelectChange}
           />
-        </Box>
-      )}
-      <IconButton
-        data-testid={testIDs.header.settingsButton}
-        aria-label="Open App Settings"
-        onClick={() => setSidebarOpen(true)}
-      >
-        <SettingsOutlinedIcon />
-      </IconButton>
+        )}
+        <IconButton
+          data-testid={testIDs.header.settingsButton}
+          aria-label="Open App Settings"
+          onClick={() => setSidebarOpen(true)}
+        >
+          <SettingsOutlinedIcon />
+        </IconButton>
+      </Box>
     </>
   )
 }
@@ -143,11 +153,18 @@ export default function MenuBar() {
       elevation={0}
     >
       <Toolbar>
-        {/* Logo and/or Text */}
-        <LeftGroup />
-        <Box sx={{ flexGrow: 1, display: { xs: 'none', sm: 'flex' } }} />
-        {/* Optional version dropdown and settings button */}
-        <RightGroup setSidebarOpen={setSidebarOpen} />
+        <Grid container alignItems="center" justifyContent="space-between" sx={{ width: '100%' }} wrap="nowrap">
+          {/* Logo and/or Text */}
+          <Grid size="auto">
+            <LeftGroup />
+          </Grid>
+          {/* Spacer */}
+          <Grid size="auto"></Grid>
+          {/* Optional version dropdown and settings button */}
+          <Grid size={{ sm: 12, md: 2 }}>
+            <RightGroup setSidebarOpen={setSidebarOpen} />
+          </Grid>
+        </Grid>
       </Toolbar>
       <SettingsSidebar open={sidebarOpen} setOpen={setSidebarOpen} appVersion={appVersion} />
     </AppBar>

--- a/src/ui/components/MenuBar.tsx
+++ b/src/ui/components/MenuBar.tsx
@@ -10,6 +10,40 @@ import VersionDropdown from './VersionDropdown'
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined'
 import SettingsSidebar from './SettingsSidebar'
 
+function LeftGroup() {
+  const theme = useTheme()
+  const [themePluginConfig, setThemePluginConfig] = useState<ThemePluginT | null>(null)
+
+  useEffect(() => {
+    fetchPluginConfig<ThemePluginT>('theme').then((config) => setThemePluginConfig(config))
+  }, [])
+
+  const logoUrl = useMemo(() => {
+    return themePluginConfig?.[theme.palette.mode]?.logo_url
+  }, [themePluginConfig, theme.palette.mode])
+
+  if (!logoUrl) {
+    return null
+  }
+
+  return (
+    <Box
+      sx={{ display: { xs: 'none', sm: 'flex' }, alignItems: 'center', flexGrow: 0, mr: 2, cursor: 'pointer' }}
+      data-testid={testIDs.header.logo.main}
+      component="a"
+      href="/"
+    >
+      {logoUrl !== null ? (
+        <img data-testid={testIDs.header.logo.image} src={logoUrl} alt="logo" style={{ maxHeight: 34 }} />
+      ) : (
+        <Typography data-testid={testIDs.header.logo.text} variant="h6" sx={{ color: theme.palette.text.primary }}>
+          vdoc
+        </Typography>
+      )}
+    </Box>
+  )
+}
+
 export default function MenuBar() {
   const navigate = useNavigate({ from: '/$projectName/$version/$' })
   const params = useParams({ strict: false })
@@ -18,17 +52,12 @@ export default function MenuBar() {
 
   const [projectName, setProjectName] = useState<string | undefined>(undefined)
   const [appVersion, setAppVersion] = useState<string | undefined>(undefined)
-  const [themePluginConfig, setThemePluginConfig] = useState<ThemePluginT | null>(null)
+
   const [projectVersions, setProjectVersions] = useState<string[] | undefined>(undefined)
   const [latestVersion, setLatestVersion] = useState<string | undefined>(undefined)
+
   useEffect(() => {
-    const fetchData = async (): Promise<[string, ThemePluginT]> => {
-      return await Promise.all([fetchAppVersion(), fetchPluginConfig<ThemePluginT>('theme')])
-    }
-    fetchData().then(([appVersion, themePluginConfig]) => {
-      setAppVersion(appVersion)
-      setThemePluginConfig(themePluginConfig)
-    })
+    fetchAppVersion().then((appVersion) => setAppVersion(appVersion))
   }, [theme])
 
   useEffect(() => {
@@ -75,10 +104,6 @@ export default function MenuBar() {
     return result
   }, [params.version, projectVersions])
 
-  const logoUrl = useMemo(() => {
-    return themePluginConfig?.[theme.palette.mode]?.logo_url
-  }, [themePluginConfig, theme.palette.mode])
-
   return (
     <AppBar
       position="static"
@@ -89,27 +114,8 @@ export default function MenuBar() {
       elevation={0}
     >
       <Toolbar>
-        {/* Logo with Text */}
-        {logoUrl && (
-          <Box
-            sx={{ display: { xs: 'none', sm: 'flex' }, alignItems: 'center', flexGrow: 0, mr: 2, cursor: 'pointer' }}
-            data-testid={testIDs.header.logo.main}
-            component="a"
-            href="/"
-          >
-            {logoUrl !== null ? (
-              <img data-testid={testIDs.header.logo.image} src={logoUrl} alt="logo" style={{ maxHeight: 34 }} />
-            ) : (
-              <Typography
-                data-testid={testIDs.header.logo.text}
-                variant="h6"
-                sx={{ color: theme.palette.text.primary }}
-              >
-                vdoc
-              </Typography>
-            )}
-          </Box>
-        )}
+        {/* Logo and/or Text */}
+        <LeftGroup />
         <Box sx={{ flexGrow: 1, display: { xs: 'none', sm: 'flex' } }} />
         {projectVersions && latestVersion && params.version && (
           <Box sx={{ flexGrow: 0, display: { xs: 'flex' } }}>


### PR DESCRIPTION
This PR moves the different items of the UI's `MenuBar` component into separate components.
Moreover, it simplifies the item distribution using MUI `Grid`s.