### PR TITLE
fix(ui): Improve version chips on the version overview page

### DIFF
--- a/src/ui/routes/$projectName/index.tsx
+++ b/src/ui/routes/$projectName/index.tsx
@@ -57,26 +57,36 @@ function ProjectVersionsOverview() {
                       <SellIcon />
                       <Typography variant="h6">v{major}</Typography>
                     </Stack>
-                    <Stack direction="row" spacing={1}>
+                    <Grid
+                      container
+                      direction="row"
+                      spacing={1}
+                      sx={{
+                        justifyContent: 'flex-start',
+                        alignItems: 'center',
+                      }}
+                    >
                       {groupedVersions[Number(major)].map((version) => {
                         const chip = (
-                          <Chip
-                            data-testid={testIDs.project.versionOverview.majorVersionCard.versionItem.main}
-                            key={version}
-                            label={version}
-                            component="a"
-                            onClick={() =>
-                              router.navigate({
-                                to: '/$projectName/$version/$',
-                                from: '/$projectName',
-                                params: {
-                                  projectName: projectName,
-                                  version: version,
-                                },
-                              })
-                            }
-                            clickable
-                          />
+                          <Grid sx={{ mb: 1 }}>
+                            <Chip
+                              data-testid={testIDs.project.versionOverview.majorVersionCard.versionItem.main}
+                              key={version}
+                              label={version}
+                              component="a"
+                              onClick={() =>
+                                router.navigate({
+                                  to: '/$projectName/$version/$',
+                                  from: '/$projectName',
+                                  params: {
+                                    projectName: projectName,
+                                    version: version,
+                                  },
+                                })
+                              }
+                              clickable
+                            />
+                          </Grid>
                         )
                         return version === latestVersion ? (
                           <Badge
@@ -90,7 +100,7 @@ function ProjectVersionsOverview() {
                           chip
                         )
                       })}
-                    </Stack>
+                    </Grid>
                   </CardContent>
                 </Card>
               </Grid>


### PR DESCRIPTION
Before, some chips disappeared in the overflow.

**Before**
![Screenshot 2025-05-28 at 15-09-50 voraus robot arm package voraus Robot Arm 1 1 0 documentation](https://github.com/user-attachments/assets/c91a2d79-5a1f-4585-b9ad-8298053eba3e)

**After**
![image](https://github.com/user-attachments/assets/ca0bc61a-6b61-4f6f-a6ec-9ea3e4243477)
