### PR TITLE
fix(ui): Fix source base URL of orama links in documentation view

### DIFF
--- a/src/ui/components/plugins/OramaSearchPlugin.tsx
+++ b/src/ui/components/plugins/OramaSearchPlugin.tsx
@@ -63,6 +63,7 @@ export const OramaSearchPlugin = (config: OramaPluginT) => {
           title: 'title',
           section: 'category',
         }}
+        sourceBaseUrl={window.origin}
       />
     </Box>
   )


### PR DESCRIPTION
Links provided by orama are relative to the index route (`/`). Orama links clicked in some documentation (e.g. `/project-one/latest`) need to be relative to the window origin, not to the current project.

The [TanStack router navigation is relative](https://tanstack.com/router/latest/docs/framework/react/guide/navigation).

This resolves [BUGS-6399](https://vorausrobotik.atlassian.net/browse/BUGS-6399)

[BUGS-6399]: https://vorausrobotik.atlassian.net/browse/BUGS-6399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ