### PR TITLE
feat: Add configurable footer plugin

### DIFF
--- a/docs/plugins/footer.rst
+++ b/docs/plugins/footer.rst
@@ -1,0 +1,22 @@
+Footer Plugin
+=============
+
+**vdoc** can be extended with a footer plugin.
+
+The following settings are available:
+
+.. list-table:: Footer Plugin Environment Variables
+   :header-rows: 1
+
+   * - Environment variable
+     - Explanation
+     - Default
+     - Example
+   * - ``VDOC_PLUGINS_FOOTER_COPYRIGHT``
+     - The copyright holder without copyright mark or year.
+     - ``None``
+     - ``Example Org``
+   * - ``VDOC_PLUGINS_FOOTER_LINKS``
+     - A list of link groups to display in the footer.
+     - ``[]``
+     - ``[{"title": "Contact", "links": [{"title": "Email", "icon": "email", "href": "mailto:service@example.com"}]}]``

--- a/src/ui/components/plugins/FooterPlugin.tsx
+++ b/src/ui/components/plugins/FooterPlugin.tsx
@@ -1,0 +1,76 @@
+import { Container, Typography, Button, Link, Grid, Stack, Paper, Divider } from '@mui/material'
+import { useEffect, useState } from 'react'
+import FooterPluginT, { iconMap } from '../../interfacesAndTypes/plugins/FooterPlugin'
+import testIDs from '../../interfacesAndTypes/testIDs'
+import { fetchPluginConfig } from '../../helpers/APIFunctions'
+
+export const FooterPlugin = () => {
+  const [footerPluginConfig, setFooterPluginConfig] = useState<FooterPluginT | null>(null)
+
+  useEffect(() => {
+    fetchPluginConfig<FooterPluginT>('footer').then((config) => setFooterPluginConfig(config))
+  }, [])
+
+  if (footerPluginConfig == null || !footerPluginConfig.active) {
+    return null
+  }
+
+  return (
+    // For the elevation effect
+    <Paper data-testid={testIDs.plugins.footer.main} component="footer" elevation={4}>
+      {/* Centers content horizontally and restricts the width */}
+      <Container maxWidth="xl" sx={{ py: 1 }}>
+        <Grid container direction="row" alignItems="center" justifyContent="center" columnSpacing={6}>
+          {/* Copyright */}
+          <Grid data-testid={testIDs.plugins.footer.copyright}>
+            <Typography variant="body2" color="text.secondary">
+              © {new Date().getFullYear()} {footerPluginConfig.copyright}
+            </Typography>
+          </Grid>
+          {/* Link groups */}
+          {footerPluginConfig.links.map((linkGroup) => {
+            return (
+              <>
+                <Divider orientation="vertical" flexItem sx={{ display: { md: 'none', lg: 'block' } }} />
+                <Grid>
+                  <Stack
+                    data-testid={testIDs.plugins.footer.linkGroup.main}
+                    direction="row"
+                    style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}
+                  >
+                    {/* Link group title */}
+                    <Typography
+                      data-testid={testIDs.plugins.footer.linkGroup.title}
+                      variant="body2"
+                      color="text.secondary"
+                      mr={2}
+                    >
+                      {linkGroup.title}
+                    </Typography>
+                    {/* Link group links */}
+                    {linkGroup.links.map((link) => {
+                      const LinkIcon = iconMap[link.icon]
+                      return (
+                        <Button
+                          data-testid={testIDs.plugins.footer.linkGroup.link.main}
+                          key={link.href}
+                          sx={{ textTransform: 'none', mr: 1 }}
+                          component={Link}
+                          href={link.href}
+                          startIcon={<LinkIcon />}
+                          variant="outlined"
+                        >
+                          {link.title}
+                        </Button>
+                      )
+                    })}
+                  </Stack>
+                </Grid>
+              </>
+            )
+          })}
+        </Grid>
+      </Container>
+    </Paper>
+  )
+}

--- a/src/ui/interfacesAndTypes/plugins/FooterPlugin.ts
+++ b/src/ui/interfacesAndTypes/plugins/FooterPlugin.ts
@@ -1,0 +1,39 @@
+import { PluginBaseT } from './PluginBase'
+import EmailIcon from '@mui/icons-material/Email'
+import SupportAgentIcon from '@mui/icons-material/SupportAgent'
+import PublicIcon from '@mui/icons-material/Public'
+import GitHubIcon from '@mui/icons-material/GitHub'
+import BugReportIcon from '@mui/icons-material/BugReport'
+import HomeIcon from '@mui/icons-material/Home'
+
+type iconT = 'email' | 'support' | 'public' | 'github' | 'bugs' | 'home'
+
+export const iconMap: Record<iconT, React.ElementType> = {
+  email: EmailIcon,
+  support: SupportAgentIcon,
+  public: PublicIcon,
+  github: GitHubIcon,
+  bugs: BugReportIcon,
+  home: HomeIcon,
+}
+
+export type FooterLinkT = {
+  title: string
+  icon: iconT
+  href: string
+}
+
+export type FooterLinkGroupT = {
+  title: string
+  icon: iconT
+  links: FooterLinkT[]
+}
+
+type FooterPluginFields = {
+  links: FooterLinkGroupT[]
+  copyright?: string
+}
+
+export type FooterPluginT = PluginBaseT<FooterPluginFields>
+
+export default FooterPluginT

--- a/src/ui/interfacesAndTypes/plugins/PluginBase.ts
+++ b/src/ui/interfacesAndTypes/plugins/PluginBase.ts
@@ -3,6 +3,10 @@ export interface PluginBaseI {
   name: string
 }
 
+type OptionalNullable<T> = {
+  [K in keyof T]?: T[K] | null
+}
+
 export type PluginBaseT<TFields> =
-  | (PluginBaseI & { name: string; active: false } & { [K in keyof TFields]: TFields[K] | null })
-  | (PluginBaseI & { name: string; active: true } & TFields)
+  | (PluginBaseI & { active: false } & OptionalNullable<TFields>)
+  | (PluginBaseI & { active: true } & TFields)

--- a/src/ui/interfacesAndTypes/testIDs.ts
+++ b/src/ui/interfacesAndTypes/testIDs.ts
@@ -83,6 +83,17 @@ export const testIDs = {
       searchButton: 'plugins.orama.searchButton',
       searchBox: 'plugins.orama.searchBox',
     },
+    footer: {
+      main: 'footer',
+      copyright: 'footer.copyright',
+      linkGroup: {
+        main: 'footer.linkGroup',
+        title: 'footer.linkGroup.title',
+        link: {
+          main: 'footer.linkGroup.link.main',
+        },
+      },
+    },
   },
 } as const
 

--- a/src/ui/routes/__root.tsx
+++ b/src/ui/routes/__root.tsx
@@ -1,6 +1,7 @@
 import { createRootRoute, Outlet } from '@tanstack/react-router'
 import InitColorSchemeScript from '@mui/material/InitColorSchemeScript'
 import MenuBar from '../components/MenuBar'
+import { FooterPlugin } from '../components/plugins/FooterPlugin'
 import { Box, CssBaseline, ThemeProvider, createTheme, useColorScheme } from '@mui/material'
 const theme = createTheme({
   colorSchemes: {
@@ -18,9 +19,20 @@ function ThemedComponent() {
     return null
   }
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+    <Box id="rootComponent" sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
       <MenuBar />
-      <Outlet />
+      <Box
+        sx={{
+          height: '100vh',
+          flex: 1,
+          overflowY: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <Outlet />
+      </Box>
+      <FooterPlugin />
     </Box>
   )
 }

--- a/src/vdoc/models/plugins/__init__.py
+++ b/src/vdoc/models/plugins/__init__.py
@@ -1,9 +1,11 @@
 """Contains all plugins models."""
 
+from vdoc.models.plugins.footer import FooterPlugin
 from vdoc.models.plugins.orama import OramaPlugin
 from vdoc.models.plugins.theme import ThemePlugin
 
 __all__ = [
     "ThemePlugin",
     "OramaPlugin",
+    "FooterPlugin",
 ]

--- a/src/vdoc/models/plugins/base.py
+++ b/src/vdoc/models/plugins/base.py
@@ -15,7 +15,7 @@ from vdoc.constants import CONFIG_ENV_PREFIX_PLUGINS
 _logger = logging.getLogger(__name__)
 
 
-ValidPluginsT = Literal["theme", "orama"]
+ValidPluginsT = Literal["theme", "orama", "footer"]
 
 
 class Plugin(BaseSettings, ABC):

--- a/src/vdoc/models/plugins/footer.py
+++ b/src/vdoc/models/plugins/footer.py
@@ -1,0 +1,42 @@
+"""Contains the footer plugin."""
+
+from typing import Literal
+
+from pydantic import AnyUrl, BaseModel
+
+from vdoc.models.plugins.base import Plugin, ValidPluginsT
+
+LinkIconT = Literal["email", "support", "public", "bugs", "github", "home"]
+
+
+class FooterLink(BaseModel):
+    """Pydantic model for a footer link."""
+
+    title: str
+    href: AnyUrl
+    icon: LinkIconT
+
+
+class FooterLinkGroup(BaseModel):
+    """Pydantic model for a footer link group."""
+
+    title: str
+    links: list[FooterLink]
+
+
+class FooterPlugin(Plugin):
+    """Footer plugin model for vdoc."""
+
+    name: ValidPluginsT = "footer"
+
+    links: list[FooterLinkGroup] = []
+    copyright: str | None = None
+
+    @property
+    def active(self) -> bool:
+        """Check if the plugin is active.
+
+        Returns:
+            True if the plugin is active, False otherwise.
+        """
+        return self.copyright is not None or len(self.links) > 0

--- a/tests/ui/plugins/testFooterPlugin.spec.ts
+++ b/tests/ui/plugins/testFooterPlugin.spec.ts
@@ -1,0 +1,121 @@
+import { expect } from '@playwright/test'
+import test, { prepareTestSuite } from '../base'
+import testIDs from '../../../src/ui/interfacesAndTypes/testIDs'
+import { FooterPluginT } from '../../../src/ui/interfacesAndTypes/plugins/FooterPlugin'
+await prepareTestSuite(test)
+
+const footerDisabledDataMock: FooterPluginT = {
+  name: 'footer',
+  active: false,
+}
+
+const footerEnabledDataMock: FooterPluginT = {
+  name: 'footer',
+  copyright: 'Example GmbH',
+  links: [
+    {
+      title: 'Submit Feedback',
+      icon: 'bugs',
+      links: [
+        {
+          title: 'Email',
+          icon: 'email',
+          href: 'mailto:service@example.com',
+        },
+        {
+          title: 'Service Board',
+          icon: 'support',
+          href: 'https://example.com',
+        },
+      ],
+    },
+    {
+      title: 'Links',
+      icon: 'public',
+      links: [
+        {
+          title: 'example.com',
+          icon: 'home',
+          href: 'https://example.com',
+        },
+        {
+          title: 'GitHub',
+          icon: 'github',
+          href: 'https://github.com/example/',
+        },
+      ],
+    },
+  ],
+  active: true,
+}
+
+test.describe('Footer plugin tests', () => {
+  const sites = ['/', '/example-project-01/latest/', '/example-project-01/']
+  sites.forEach((site: string) => {
+    test(`Footer plugin must not be visible on site ${site} when inactive`, async ({ page }) => {
+      // GIVEN: The footer plugin is inactive
+      await page.route('*/**/api/plugins/footer/', (route) =>
+        route.fulfill({
+          json: footerDisabledDataMock,
+        })
+      )
+      // WHEN: The user navigates to the tested page
+      await page.goto(site)
+      await page.waitForLoadState()
+
+      // THEN: The footer must not be visible
+      await expect(page.getByTestId(testIDs.plugins.footer.main)).not.toBeVisible()
+    })
+  })
+  sites.forEach((site: string) => {
+    test(`Footer plugin must be visible on site ${site} when active`, async ({ page }) => {
+      // GIVEN: The footer plugin is active
+      await page.route('*/**/api/plugins/footer/', (route) =>
+        route.fulfill({
+          json: footerEnabledDataMock,
+        })
+      )
+      // WHEN: The user navigates to the tested page
+      await page.goto(site)
+      await page.waitForLoadState()
+
+      // THEN: The footer must be visible
+      await expect(page.getByTestId(testIDs.plugins.footer.main)).toBeVisible()
+
+      // THEN: The copyright must be visible
+      await expect(page.getByTestId(testIDs.plugins.footer.copyright)).toHaveText(
+        `© ${new Date().getFullYear()} Example GmbH`
+      )
+
+      // THEN: All link groups must be visible
+      const linkGroups = page.getByTestId(testIDs.plugins.footer.linkGroup.main)
+      await expect(linkGroups).toHaveCount(2)
+
+      // THEN: All links must be visible and have correct values
+      const expectedLinks = [
+        {
+          title: 'Email',
+          href: 'mailto:service@example.com',
+        },
+        {
+          title: 'Service Board',
+          href: 'https://example.com',
+        },
+        {
+          title: 'example.com',
+          href: 'https://example.com',
+        },
+        {
+          title: 'GitHub',
+          href: 'https://github.com/example/',
+        },
+      ]
+      const linkLocators = page.getByTestId(testIDs.plugins.footer.linkGroup.link.main)
+      await expect(linkLocators).toHaveCount(expectedLinks.length)
+      for (const [index, link] of expectedLinks.entries()) {
+        await expect(linkLocators.nth(index)).toHaveText(link.title)
+        await expect(linkLocators.nth(index)).toHaveAttribute('href', link.href)
+      }
+    })
+  })
+})

--- a/tests/unit/api/routes/plugins/test_load_routers.py
+++ b/tests/unit/api/routes/plugins/test_load_routers.py
@@ -56,10 +56,7 @@ def test_plugin_routers_are_added(load_plugins_mock: MagicMock, request: Fixture
 def test_inactive_plugins(api: TestClient) -> None:
     response = api.get("/api/plugins/")
     assert response.status_code == 200
-    assert response.json() == [
-        "orama",
-        "theme",
-    ]
+    assert response.json() == ["footer", "orama", "theme"]
 
     # Test the Orama plugin endpoint
     assert api.get("/api/plugins/orama/").json() == {

--- a/tests/unit/models/plugins/test_footer_plugin.py
+++ b/tests/unit/models/plugins/test_footer_plugin.py
@@ -1,0 +1,42 @@
+"""Contains all unit tests for the Footer plugin."""
+
+import os
+from unittest.mock import patch
+
+from pydantic import AnyUrl
+
+from vdoc.models.plugins import FooterPlugin
+
+
+@patch.dict(os.environ, clear=True)
+def test_footer_plugin() -> None:
+    plugin = FooterPlugin(copyright="Example GmbH")
+
+    assert plugin.active is True
+    assert plugin.copyright == "Example GmbH"
+    assert len(plugin.links) == 0
+
+
+def test_footer_plugin_inactive() -> None:
+    plugin = FooterPlugin()
+    assert plugin.active is False
+
+
+@patch.dict(
+    os.environ,
+    {
+        "VDOC_PLUGINS_FOOTER_COPYRIGHT": "Example GmbH",
+        # pylint: disable-next=line-too-long
+        "VDOC_PLUGINS_FOOTER_LINKS": '[{"title": "Contact", "links": [{"title": "Email", "icon": "email", "href": "mailto:service@example.com"}]}]',
+    },
+)
+def test_footer_plugin_from_env() -> None:
+    plugin = FooterPlugin()
+    assert plugin.name == "footer"
+    assert plugin.copyright == "Example GmbH"
+    assert len(plugin.links) == 1
+    assert plugin.links[0].title == "Contact"
+    assert len(plugin.links[0].links) == 1
+    assert plugin.links[0].links[0].title == "Email"
+    assert plugin.links[0].links[0].icon == "email"
+    assert plugin.links[0].links[0].href == AnyUrl("mailto:service@example.com")

--- a/tests/unit/models/plugins/test_load_plugins.py
+++ b/tests/unit/models/plugins/test_load_plugins.py
@@ -8,7 +8,7 @@ from pydantic import ValidationError
 from pytest import LogCaptureFixture
 
 from vdoc.constants import CONFIG_ENV_PREFIX_PLUGINS
-from vdoc.models.plugins import OramaPlugin, ThemePlugin
+from vdoc.models.plugins import FooterPlugin, OramaPlugin, ThemePlugin
 from vdoc.models.plugins.base import Plugin
 
 
@@ -16,14 +16,17 @@ def test_load_plugins_defaults(caplog: LogCaptureFixture) -> None:
     with caplog.at_level("INFO"):
         plugins = list(Plugin.load_plugins())
 
-    assert len(plugins) == 2
+    assert len(plugins) == 3
 
-    assert isinstance(plugins[0], OramaPlugin)
+    assert isinstance(plugins[0], FooterPlugin)
     assert plugins[0].active is False
-    assert isinstance(plugins[1], ThemePlugin)
-    assert plugins[1].active is True
+    assert isinstance(plugins[1], OramaPlugin)
+    assert plugins[1].active is False
+    assert isinstance(plugins[2], ThemePlugin)
+    assert plugins[2].active is True
 
     assert caplog.messages == [
+        "Loaded plugin: 'FooterPlugin'",
         "Loaded plugin: 'OramaPlugin'",
         "Loaded plugin: 'ThemePlugin'",
     ]
@@ -34,20 +37,24 @@ def test_load_plugins_defaults(caplog: LogCaptureFixture) -> None:
     {
         f"{CONFIG_ENV_PREFIX_PLUGINS}ORAMA_ENDPOINT": "https://cloud.orama.run/v1/indexes/demo-index",
         f"{CONFIG_ENV_PREFIX_PLUGINS}ORAMA_API_KEY": "super-secret-key",
+        f"{CONFIG_ENV_PREFIX_PLUGINS}FOOTER_COPYRIGHT": "foo",
     },
 )
 def test_load_plugins_orama_active(caplog: LogCaptureFixture) -> None:
     with caplog.at_level("INFO"):
         plugins = list(Plugin.load_plugins())
 
-    assert len(plugins) == 2
+    assert len(plugins) == 3
 
-    assert isinstance(plugins[0], OramaPlugin)
+    assert isinstance(plugins[0], FooterPlugin)
     assert plugins[0].active is True
-    assert isinstance(plugins[1], ThemePlugin)
+    assert isinstance(plugins[1], OramaPlugin)
     assert plugins[1].active is True
+    assert isinstance(plugins[2], ThemePlugin)
+    assert plugins[2].active is True
 
     assert caplog.messages == [
+        "Loaded plugin: 'FooterPlugin'",
         "Loaded plugin: 'OramaPlugin'",
         "Loaded plugin: 'ThemePlugin'",
     ]
@@ -62,8 +69,9 @@ def test_load_plugins_orama_active(caplog: LogCaptureFixture) -> None:
 def test_load_plugins_error(caplog: LogCaptureFixture) -> None:
     with caplog.at_level("INFO"), pytest.raises(ValidationError, match="Input should be a valid URL"):
         list(Plugin.load_plugins())
-    assert caplog.messages[0] == "Loaded plugin: 'OramaPlugin'"
-    assert caplog.messages[1].startswith(
+    assert caplog.messages[0] == "Loaded plugin: 'FooterPlugin'"
+    assert caplog.messages[1] == "Loaded plugin: 'OramaPlugin'"
+    assert caplog.messages[2].startswith(
         "Failed to load plugin 'ThemePlugin': "
         "1 validation error for ThemePlugin\nlight.logo_url\n  Input should be a valid URL"
     )


### PR DESCRIPTION
## :sparkles: Footer Plugin

![image](https://github.com/user-attachments/assets/799f1eb7-d5ad-49cb-bd8b-fe9b0941e26e)
![image](https://github.com/user-attachments/assets/1d35b5ec-d4ce-49bd-b3f7-43783cf5a7b6)


The footer can be enabled by setting the environment variables `VDOC_PLUGINS_FOOTER_COPYRIGHT` and `VDOC_PLUGINS_FOOTER_LINKS`.

An example can be found in the [documentation](https://vorausrobotik.github.io/vdoc/plugins/footer.html).