### PR TITLE
feat(footer-plugin): Make link targets configurable (new tab is default)

### DIFF
--- a/src/ui/components/plugins/FooterPlugin.tsx
+++ b/src/ui/components/plugins/FooterPlugin.tsx
@@ -57,6 +57,7 @@ export const FooterPlugin = () => {
                           sx={{ textTransform: 'none', mr: 1 }}
                           component={Link}
                           href={link.href}
+                          target={link.target}
                           startIcon={<LinkIcon />}
                           variant="outlined"
                         >

--- a/src/ui/interfacesAndTypes/plugins/FooterPlugin.ts
+++ b/src/ui/interfacesAndTypes/plugins/FooterPlugin.ts
@@ -7,6 +7,7 @@ import BugReportIcon from '@mui/icons-material/BugReport'
 import HomeIcon from '@mui/icons-material/Home'
 
 type iconT = 'email' | 'support' | 'public' | 'github' | 'bugs' | 'home'
+type targetT = '_blank' | '_self' | '_parent' | '_top'
 
 export const iconMap: Record<iconT, React.ElementType> = {
   email: EmailIcon,
@@ -21,6 +22,7 @@ export type FooterLinkT = {
   title: string
   icon: iconT
   href: string
+  target: targetT
 }
 
 export type FooterLinkGroupT = {

--- a/src/vdoc/models/plugins/footer.py
+++ b/src/vdoc/models/plugins/footer.py
@@ -7,6 +7,13 @@ from pydantic import AnyUrl, BaseModel
 from vdoc.models.plugins.base import Plugin, ValidPluginsT
 
 LinkIconT = Literal["email", "support", "public", "bugs", "github", "home"]
+# https://www.w3schools.com/tags/att_a_target.asp
+LinkTargetT = Literal[
+    "_blank",  # Opens the linked document in a new window or tab
+    "_self",  # Opens the linked document in the same frame as it was clicked
+    "_parent",  # Opens the linked document in the parent frame
+    "_top",  #  Opens the linked document in the full body of the window
+]
 
 
 class FooterLink(BaseModel):
@@ -15,6 +22,7 @@ class FooterLink(BaseModel):
     title: str
     href: AnyUrl
     icon: LinkIconT
+    target: LinkTargetT = "_blank"
 
 
 class FooterLinkGroup(BaseModel):

--- a/tests/ui/plugins/testFooterPlugin.spec.ts
+++ b/tests/ui/plugins/testFooterPlugin.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from '@playwright/test'
 import test, { prepareTestSuite } from '../base'
+import { assertLinkOpensInNewTab } from '../helpers'
 import testIDs from '../../../src/ui/interfacesAndTypes/testIDs'
 import { FooterPluginT } from '../../../src/ui/interfacesAndTypes/plugins/FooterPlugin'
 await prepareTestSuite(test)
@@ -21,11 +22,13 @@ const footerEnabledDataMock: FooterPluginT = {
           title: 'Email',
           icon: 'email',
           href: 'mailto:service@example.com',
+          target: '_self',
         },
         {
           title: 'Service Board',
           icon: 'support',
-          href: 'https://example.com',
+          href: 'https://example.com/',
+          target: '_blank',
         },
       ],
     },
@@ -36,12 +39,14 @@ const footerEnabledDataMock: FooterPluginT = {
         {
           title: 'example.com',
           icon: 'home',
-          href: 'https://example.com',
+          href: 'https://example.com/',
+          target: '_blank',
         },
         {
           title: 'GitHub',
           icon: 'github',
           href: 'https://github.com/example/',
+          target: '_blank',
         },
       ],
     },
@@ -96,18 +101,22 @@ test.describe('Footer plugin tests', () => {
         {
           title: 'Email',
           href: 'mailto:service@example.com',
+          target: '_self',
         },
         {
           title: 'Service Board',
-          href: 'https://example.com',
+          href: 'https://example.com/',
+          target: '_blank',
         },
         {
           title: 'example.com',
-          href: 'https://example.com',
+          href: 'https://example.com/',
+          target: '_blank',
         },
         {
           title: 'GitHub',
           href: 'https://github.com/example/',
+          target: '_blank',
         },
       ]
       const linkLocators = page.getByTestId(testIDs.plugins.footer.linkGroup.link.main)
@@ -115,6 +124,10 @@ test.describe('Footer plugin tests', () => {
       for (const [index, link] of expectedLinks.entries()) {
         await expect(linkLocators.nth(index)).toHaveText(link.title)
         await expect(linkLocators.nth(index)).toHaveAttribute('href', link.href)
+        await expect(linkLocators.nth(index)).toHaveAttribute('target', link.target)
+        if (link.target === '_blank') {
+          await assertLinkOpensInNewTab(page, linkLocators.nth(index), link.href)
+        }
       }
     })
   })

--- a/tests/unit/models/plugins/test_footer_plugin.py
+++ b/tests/unit/models/plugins/test_footer_plugin.py
@@ -40,3 +40,4 @@ def test_footer_plugin_from_env() -> None:
     assert plugin.links[0].links[0].title == "Email"
     assert plugin.links[0].links[0].icon == "email"
     assert plugin.links[0].links[0].href == AnyUrl("mailto:service@example.com")
+    assert plugin.links[0].links[0].target == "_blank"


### PR DESCRIPTION
Allows configuration of the footer link targets.