### PR TITLE
fix(ui): Remove `/undefined` suffix from documentation latest links

### DIFF
--- a/src/ui/routes/index.lazy.tsx
+++ b/src/ui/routes/index.lazy.tsx
@@ -73,7 +73,7 @@ function IndexProjectCard({ project }: { project: Project }) {
               testIDs.landingPage.projectCategories.projectCategory.projects.projectCard.actions.documentationLink
             }
             to={`/$projectName/$version/$`}
-            params={{ projectName: project.name, version: 'latest' }}
+            params={{ projectName: project.name, version: 'latest', _splat: '' }}
             size="small"
           >
             Documentation

--- a/tests/ui/helpers.ts
+++ b/tests/ui/helpers.ts
@@ -172,13 +172,14 @@ export const assertIndexPage = async (
         ).toContainText(project.display_name)
 
         // Assert documentation button
-        await expect(
-          projectCards
-            .nth(projectIndex)
-            .getByTestId(
-              testIDs.landingPage.projectCategories.projectCategory.projects.projectCard.actions.documentationLink
-            )
-        ).toBeVisible()
+        const documentationButton = projectCards
+          .nth(projectIndex)
+          .getByTestId(
+            testIDs.landingPage.projectCategories.projectCategory.projects.projectCard.actions.documentationLink
+          )
+        await expect(documentationButton).toBeVisible()
+        await expect(documentationButton).toHaveText('Documentation')
+        await expect(documentationButton).toHaveAttribute('href', `/${project.name}/latest/`)
       }
     }
   }


### PR DESCRIPTION
The tanstack router `_splat` parameter needs to be set explicitely to an empty string. Otherwise, `undefined` is interpreted as string.