### PR TITLE
fix(ui): Dynamically size content area based on footer height

### DIFF
--- a/src/ui/components/ScrollToTop.tsx
+++ b/src/ui/components/ScrollToTop.tsx
@@ -20,7 +20,7 @@ export default function ScrollToTop({ visible, onScrollToTop }: ScrollToTopProps
         aria-label="scroll to top"
         sx={{
           position: 'fixed',
-          bottom: theme.spacing(8),
+          bottom: theme.spacing(2),
           right: theme.spacing(2),
         }}
       >

--- a/src/ui/components/plugins/FooterPlugin.tsx
+++ b/src/ui/components/plugins/FooterPlugin.tsx
@@ -1,4 +1,4 @@
-import { Container, Typography, Button, Link, Grid, Stack, Paper, Divider } from '@mui/material'
+import { Container, Typography, Button, Link, Grid, Stack, Paper, Divider, useTheme } from '@mui/material'
 import { useEffect, useState } from 'react'
 import FooterPluginT, { iconMap } from '../../interfacesAndTypes/plugins/FooterPlugin'
 import testIDs from '../../interfacesAndTypes/testIDs'
@@ -6,6 +6,8 @@ import { fetchPluginConfig } from '../../helpers/APIFunctions'
 
 export const FooterPlugin = () => {
   const [footerPluginConfig, setFooterPluginConfig] = useState<FooterPluginT | null>(null)
+
+  const theme = useTheme()
 
   useEffect(() => {
     fetchPluginConfig<FooterPluginT>('footer').then((config) => setFooterPluginConfig(config))
@@ -17,7 +19,12 @@ export const FooterPlugin = () => {
 
   return (
     // For the elevation effect
-    <Paper data-testid={testIDs.plugins.footer.main} component="footer" elevation={4}>
+    <Paper
+      data-testid={testIDs.plugins.footer.main}
+      component="footer"
+      elevation={4}
+      sx={{ background: theme.palette.mode === 'dark' ? 'transparent' : theme.palette.background.default }}
+    >
       {/* Centers content horizontally and restricts the width */}
       <Container maxWidth="xl" sx={{ py: 1 }}>
         <Grid container direction="row" alignItems="center" justifyContent="center" columnSpacing={6}>

--- a/src/ui/interfacesAndTypes/testIDs.ts
+++ b/src/ui/interfacesAndTypes/testIDs.ts
@@ -32,6 +32,7 @@ export const testIDs = {
   loadingIndicator: {
     main: 'loadingIndicator',
   },
+  contentArea: 'contentArea',
   scrollToTop: 'scrollToTop',
   landingPage: {
     main: 'landingPage',

--- a/src/ui/routes/__root.tsx
+++ b/src/ui/routes/__root.tsx
@@ -4,7 +4,7 @@ import MenuBar from '../components/MenuBar'
 import { FooterPlugin } from '../components/plugins/FooterPlugin'
 import ScrollToTop from '../components/ScrollToTop'
 import { Box, CssBaseline, ThemeProvider, createTheme, useColorScheme, Slide } from '@mui/material'
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import { IFrameScrollProvider, useIFrameScroll } from '../contexts/IFrameScrollContext'
 
 const theme = createTheme({
@@ -56,6 +56,19 @@ function ThemedComponent() {
   const lastScrollY = useRef(0)
   const [hideElements, setHideElements] = useState(false)
   const [showScrollToTop, setShowScrollToTop] = useState(false)
+  const [footerHeight, setFooterHeight] = useState(0)
+
+  const footerRef = useCallback((node: HTMLDivElement | null) => {
+    if (!node) {
+      setFooterHeight(0)
+      return
+    }
+    const observer = new ResizeObserver(() => {
+      setFooterHeight(node.getBoundingClientRect().height)
+    })
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [])
 
   useEffect(() => {
     const isScrollingDown = scrollY > lastScrollY.current
@@ -88,20 +101,21 @@ function ThemedComponent() {
     <Box id="rootComponent" sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
       <MenuBar hide={hideElements} />
       <Box
+        data-testid="contentArea"
         sx={{
           flex: 1,
           overflowY: 'auto',
           display: 'flex',
           flexDirection: 'column',
           pt: hideElements ? 0 : '64px',
-          pb: hideElements ? 0 : '64px',
+          pb: hideElements ? 0 : `${footerHeight}px`,
           transition: 'padding 0.3s',
         }}
       >
         <Outlet />
       </Box>
       <Slide appear={false} direction="up" in={!hideElements}>
-        <Box sx={{ position: 'fixed', bottom: 0, width: '100%', zIndex: 1100 }}>
+        <Box ref={footerRef} sx={{ position: 'fixed', bottom: 0, width: '100%', zIndex: 1100 }}>
           <FooterPlugin />
         </Box>
       </Slide>

--- a/tests/ui/helpers.ts
+++ b/tests/ui/helpers.ts
@@ -448,3 +448,16 @@ export async function expectHeaderVisible(header: Locator) {
     expect(rect!.y).toBeLessThan(20)
   }).toPass({ timeout: 5000 })
 }
+
+/**
+ * Returns the computed top and bottom padding of the content area.
+ *
+ * @param page The playwright page object.
+ * @returns An object with `paddingTop` and `paddingBottom` in pixels.
+ */
+export async function getContentPadding(page: Page) {
+  const contentBox = page.getByTestId(testIDs.contentArea)
+  const paddingTop = await contentBox.evaluate((el) => parseFloat(getComputedStyle(el).paddingTop))
+  const paddingBottom = await contentBox.evaluate((el) => parseFloat(getComputedStyle(el).paddingBottom))
+  return { paddingTop, paddingBottom }
+}

--- a/tests/ui/testScrollBehavior.spec.ts
+++ b/tests/ui/testScrollBehavior.spec.ts
@@ -7,7 +7,9 @@ import {
   scrollIframeBelowShowThreshold,
   expectHeaderHidden,
   expectHeaderVisible,
+  getContentPadding,
 } from './helpers'
+import { FooterPluginT } from '../../src/ui/interfacesAndTypes/plugins/FooterPlugin'
 
 await prepareTestSuite(test)
 
@@ -79,5 +81,53 @@ test.describe('Scroll behavior', () => {
         expect(scrollTop).toBeLessThan(50)
       }).toPass({ timeout: 3000 })
     })
+  })
+
+  const footerEnabledMock: FooterPluginT = {
+    name: 'footer',
+    active: true,
+    links: [
+      {
+        title: 'Links',
+        icon: 'public',
+        links: [{ title: 'Home', icon: 'home', href: 'https://example.com', target: '_blank' }],
+      },
+    ],
+    copyright: 'Test GmbH',
+  }
+
+  const footerDisabledMock: FooterPluginT = {
+    name: 'footer',
+    active: false,
+  }
+
+  test('content padding should match app bar and footer height when footer is enabled', async ({ page }) => {
+    await page.route('*/**/api/plugins/footer/', (route) => route.fulfill({ json: footerEnabledMock }))
+    await page.goto('/example-project-01/1.0.0/')
+    const footer = page.getByTestId(testIDs.plugins.footer.main)
+    await expect(footer).toBeVisible()
+
+    await expect(async () => {
+      const { paddingTop, paddingBottom } = await getContentPadding(page)
+      const headerBox = (await header.boundingBox())!
+      const footerBox = (await footer.boundingBox())!
+
+      expect(paddingTop).toBeCloseTo(headerBox.height, 0)
+      expect(paddingBottom).toBeCloseTo(footerBox.height, 0)
+    }).toPass({ timeout: 5000 })
+  })
+
+  test('content padding should match app bar height when footer is disabled', async ({ page }) => {
+    await page.route('*/**/api/plugins/footer/', (route) => route.fulfill({ json: footerDisabledMock }))
+    await page.goto('/example-project-01/1.0.0/')
+    await expect(page.getByTestId(testIDs.plugins.footer.main)).not.toBeVisible()
+
+    await expect(async () => {
+      const { paddingTop, paddingBottom } = await getContentPadding(page)
+      const headerBox = (await header.boundingBox())!
+
+      expect(paddingTop).toBeCloseTo(headerBox.height, 0)
+      expect(paddingBottom).toBe(0)
+    }).toPass({ timeout: 5000 })
   })
 })


### PR DESCRIPTION
The content area bottom padding was hardcoded to 64px, causing a visible gap between the iframe content and the footer bar when the footer's actual rendered height differed from 64px. The scroll-to-top button had the same issue, positioned at a fixed theme.spacing(8) from the bottom regardless of footer size.

**Before**
<img width="969" height="150" alt="Screenshot 2026-04-09 at 08-38-09 voraus Software Manual Software Manual" src="https://github.com/user-attachments/assets/69721cbf-e81c-4352-86cf-1046ae5af5a0" />

**After**
<img width="967" height="150" alt="Screenshot 2026-04-09 at 08-37-48 voraus Software Manual Software Manual" src="https://github.com/user-attachments/assets/6a104568-9fd0-4581-a412-b567b21219a4" />

- Replaced the hardcoded pb: '64px' with a dynamic value measured via ResizeObserver on the footer container
- Uses a React 19 callback ref with cleanup return to observe the footer's bounding rect height
- When the footer plugin is inactive (renders null), height correctly falls back to 0
- Added data-testid="contentArea" to the content Box for testability
