### PR TITLE
fix(ui): Set app bar color to `transparent` again on dark mode

### DIFF
--- a/src/ui/components/MenuBar.tsx
+++ b/src/ui/components/MenuBar.tsx
@@ -169,8 +169,7 @@ export default function MenuBar({ hide = false }: { hide?: boolean }) {
         position="fixed"
         data-testid={testIDs.header.main}
         sx={{
-          background: theme.palette.background.default,
-          zIndex: 1200,
+          background: theme.palette.mode === 'dark' ? 'transparent' : theme.palette.background.default,
         }}
         elevation={0}
       >

--- a/tests/ui/base.ts
+++ b/tests/ui/base.ts
@@ -133,7 +133,7 @@ interface ColorModeProps {
 
 export const themes: Pick<Record<ColorMode, ColorModeProps>, 'light' | 'dark'> = {
   dark: {
-    appBarColor: 'rgb(18, 18, 18)',
+    appBarColor: 'rgba(0, 0, 0, 0)',
     backgroundColor: 'rgb(18, 18, 18)',
     errorColor: 'rgb(214, 17, 22)',
     successColor: 'rgb(102, 187, 106)',


### PR DESCRIPTION
This change was introduced in [#242](https://github.com/vorausrobotik/vdoc/pull/242/changes#diff-1efaf31b32abeb8bcc599b18398442b8c27b90336bfeedf585357bd3c03427deL170).
