### PR TITLE
fix(ci): Move PyPI trusted publish to top-level pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -51,6 +51,27 @@ jobs:
         - setup
       secrets: inherit
 
+    # Keep PyPI Trusted Publishing in the top-level workflow because
+    # reusable workflows are not officially supported by PyPI Trusted Publishing.
+    publish-pypi:
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      needs:
+      - build
+      - tests-and-coverage
+      - lint
+      runs-on: ubuntu-latest
+      steps:
+        - name: Download all artifacts
+          uses: actions/download-artifact@v8
+          with:
+            name: dist
+            path: dist
+
+        - name: Publish package distributions to PyPI
+          uses: pypa/gh-action-pypi-publish@release/v1
+          env:
+            url: https://pypi.org/p/vdoc
+
     publish:
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       needs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,21 +23,6 @@ on:
         type: string
 
 jobs:
-  publish-pypi:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: dist
-          path: dist
-
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        env:
-          url: https://pypi.org/p/vdoc
-
-
   publish-docker:
     runs-on: ubuntu-latest
     env:
@@ -88,7 +73,6 @@ jobs:
 
   publish-build-info:
     needs:
-      - publish-pypi
       - publish-docker
     runs-on: ubuntu-latest
     env:
@@ -120,7 +104,6 @@ jobs:
   create-github-release:
     runs-on: ubuntu-latest
     needs:
-      - publish-pypi
       - publish-docker
     steps:
       - name: Checkout
@@ -137,7 +120,6 @@ jobs:
   publish-docs:
     runs-on: ubuntu-latest
     needs:
-      - publish-pypi
       - publish-docker
     steps:
       - name: Download all artifacts


### PR DESCRIPTION
PyPI Trusted Publishing is not officially supported from reusable workflows.

See https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github
