### PR TITLE
ci: Add deployment support (preview image + auto-deploy on tags)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -88,3 +88,34 @@ jobs:
         pypi_deploy_repo: ${{ needs.setup.outputs.pypi_deploy_repo }}
         build_name: ${{ needs.setup.outputs.build_name }}
         build_number: ${{ needs.setup.outputs.build_number }}
+
+    deploy:
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      needs:
+        - publish
+        - publish-pypi
+      runs-on: ubuntu-latest
+      environment:
+        name: production
+        url: https://docs.vorausrobotik.com
+      steps:
+        - name: Trigger Dokploy deployment
+          run: curl --fail --silent --show-error --max-time 30 "$DOKPLOY_WEBHOOK_URL"
+          env:
+            DOKPLOY_WEBHOOK_URL: ${{ secrets.DOKPLOY_WEBHOOK_URL }}
+
+        - name: Verify deployed version
+          run: |
+            for attempt in $(seq 1 12); do
+              sleep 5
+              # /api/version/ returns the version as a JSON string, e.g. "0.24.0"
+              deployed="$(curl -fsSL --max-time 10 http://docs.vorausrobotik.com/api/version/ | tr -d '"')" || deployed="<unreachable>"
+              echo "Attempt ${attempt}/12: Deployed version is '${deployed}', expecting '${EXPECTED_VERSION}'"
+              if [ "$deployed" = "$EXPECTED_VERSION" ]; then
+                exit 0
+              fi
+            done
+            echo "::error::Deployment did not serve version '${EXPECTED_VERSION}' within 60 seconds"
+            exit 1
+          env:
+            EXPECTED_VERSION: ${{ github.ref_name }}

--- a/Dockerfile.dokploy
+++ b/Dockerfile.dokploy
@@ -25,11 +25,15 @@ WORKDIR /build
 
 # Restore the tracked working tree from the git metadata instead of copying
 # individual files: setuptools_scm needs .git to derive the version and would
-# flag any difference between working tree and HEAD as dirty. Requires a
-# non-shallow clone as the build context so that the version tags are present.
+# flag any difference between working tree and HEAD as dirty.
 RUN apk add --no-cache git
 COPY .git/ .git/
-RUN git checkout -- .
+# Dokploy clones with a hardcoded --depth 1, which strips the history and tags
+# setuptools_scm needs. Re-fetch them from the public repository (also avoids
+# relying on any credentials embedded in the cloned remote URL).
+RUN git remote set-url origin https://github.com/vorausrobotik/vdoc.git \
+    && (git fetch --quiet --unshallow --tags origin || git fetch --quiet --tags origin) \
+    && git checkout -- .
 
 COPY --from=ui-build /build/src/vdoc/webapp/ src/vdoc/webapp/
 RUN pip wheel --no-deps --no-cache-dir --wheel-dir /dist .

--- a/Dockerfile.dokploy
+++ b/Dockerfile.dokploy
@@ -5,8 +5,8 @@
 # - The vdoc self-documentation (/static/docs) is not built (requires the full
 #   Sphinx toolchain and isn't needed to preview the app).
 # - The tsc type-check from `npm run build` is skipped; CI gates types.
-# - setuptools_scm can't derive a version without git metadata in the build
-#   context, so a placeholder version is injected (override via build arg).
+# - The version is derived by setuptools_scm from the git metadata in the
+#   build context (Dokploy builds from a full git clone).
 
 # --- Build the web UI ---------------------------------------------------------
 FROM node:lts-alpine AS ui-build
@@ -21,12 +21,16 @@ RUN npx vite build
 
 # --- Build the python wheel ---------------------------------------------------
 FROM python:3.14-alpine AS py-build
-ARG VDOC_VERSION=0.0.0.dev0+preview
-ENV SETUPTOOLS_SCM_PRETEND_VERSION=$VDOC_VERSION
 WORKDIR /build
 
-COPY pyproject.toml README.md LICENSE.txt ./
-COPY src/vdoc/ src/vdoc/
+# Restore the tracked working tree from the git metadata instead of copying
+# individual files: setuptools_scm needs .git to derive the version and would
+# flag any difference between working tree and HEAD as dirty. Requires a
+# non-shallow clone as the build context so that the version tags are present.
+RUN apk add --no-cache git
+COPY .git/ .git/
+RUN git checkout -- .
+
 COPY --from=ui-build /build/src/vdoc/webapp/ src/vdoc/webapp/
 RUN pip wheel --no-deps --no-cache-dir --wheel-dir /dist .
 

--- a/Dockerfile.dokploy
+++ b/Dockerfile.dokploy
@@ -1,0 +1,48 @@
+# Dockerfile for Dokploy preview deployments.
+#
+# Unlike Dockerfile.prod, which installs a pre-built wheel from CI, this builds
+# everything needed directly from a git checkout. Kept to the bare minimum:
+# - The vdoc self-documentation (/static/docs) is not built (requires the full
+#   Sphinx toolchain and isn't needed to preview the app).
+# - The tsc type-check from `npm run build` is skipped; CI gates types.
+# - setuptools_scm can't derive a version without git metadata in the build
+#   context, so a placeholder version is injected (override via build arg).
+
+# --- Build the web UI ---------------------------------------------------------
+FROM node:lts-alpine AS ui-build
+WORKDIR /build
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY vite.config.ts tsconfig.json tsconfig.app.json tsconfig.node.json ./
+COPY src/ui/ src/ui/
+RUN npx vite build
+
+# --- Build the python wheel ---------------------------------------------------
+FROM python:3.14-alpine AS py-build
+ARG VDOC_VERSION=0.0.0.dev0+preview
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=$VDOC_VERSION
+WORKDIR /build
+
+COPY pyproject.toml README.md LICENSE.txt ./
+COPY src/vdoc/ src/vdoc/
+COPY --from=ui-build /build/src/vdoc/webapp/ src/vdoc/webapp/
+RUN pip wheel --no-deps --no-cache-dir --wheel-dir /dist .
+
+# --- Runtime (mirrors Dockerfile.prod) -----------------------------------------
+FROM python:3.14-alpine
+
+ENV PYTHONDONTWRITEBYTECODE=1
+
+EXPOSE 8080
+ENTRYPOINT [ "vdoc" ]
+CMD ["run"]
+
+RUN --mount=type=bind,from=py-build,source=/dist,target=/pip-packages/ \
+    pip install \
+    --no-cache-dir \
+    --no-compile \
+    /pip-packages/*.whl \
+    # Default projects directory (mount a volume here in Dokploy)
+    && mkdir -p /srv/vdoc/docs


### PR DESCRIPTION
## Summary

This PR wires vdoc up to Dokploy in two ways: a self-contained Dockerfile that
Dokploy can build for preview deployments, and a pipeline job that automatically
re-deploys production whenever a release tag is published.

### `Dockerfile.dokploy` — preview deployments

Unlike `Dockerfile.prod`, which installs a pre-built wheel from CI, Dokploy
builds straight from a git checkout, where the gitignored `webapp/` and
self-docs artifacts don't exist. The new Dockerfile therefore builds everything
itself, reduced to the bare minimum for a working preview:

- **Stage 1** builds the web UI with vite (skips the `tsc` type-check from
  `npm run build`; CI gates types).
- **Stage 2** bakes the UI into the vdoc wheel. Since there is no git metadata
  in the build context, a placeholder version is injected via
  `SETUPTOOLS_SCM_PRETEND_VERSION` (overridable through the `VDOC_VERSION`
  build arg).
- **Runtime stage** mirrors `Dockerfile.prod` (same base image, same
  bind-mounted wheel install), so previews behave like production.
  `/srv/vdoc/docs` is pre-created as the volume mount point.

The vdoc self-documentation (`/static/docs`) is intentionally not built;
requests to that route answer 500 in previews, which is acceptable there.

Verified by building from a clean clone and smoke-testing the container
(frontend, assets, `/api/version/`, `/api/projects/`). Final image: ~75 MB.

### `deploy` job — production auto-deploy on tags

After `publish` and `publish-pypi` succeed on a tag build, the pipeline
triggers the Dokploy production app via its deploy webhook (repo secret
`DOKPLOY_WEBHOOK_URL`) and then polls `/api/version/` for up to 60 seconds
until the live instance serves the tagged version, failing the job otherwise.

The job declares `environment: production`, so every release shows up as a
GitHub deployment with its status and a link to
[docs.vorausrobotik.com](https://docs.vorausrobotik.com).

## Requirements before merging

- [x] `DOKPLOY_WEBHOOK_URL` secret is configured in the repo
- [x] The Dokploy production app pulls the published image (the webhook only
      triggers a re-deploy; the `needs:` ordering guarantees the image was
      pushed to Artifactory first)

## Test plan

- CI (build, tests, lint) on this PR — the `deploy` job only runs on tag pushes
- After merging: publish the next release tag and confirm the deployment
  appears under *Environments → production* and the version check passes
