### PR TITLE
fix(ui): Prevent iframe bounce-back during pending navigations [BUGS-7690]

### DIFF
--- a/src/ui/components/IFrame.tsx
+++ b/src/ui/components/IFrame.tsx
@@ -5,6 +5,7 @@
 
 import { testIDs } from '../interfacesAndTypes/testIDs'
 import { useColorScheme } from '@mui/material'
+import { useRouterState } from '@tanstack/react-router'
 import { useRef, useEffect, useCallback, useState, useMemo } from 'react'
 import { sanitizeDocuUri } from '../helpers/RouteHelpers'
 import { parseIFrameHref } from '../helpers/IFrame'
@@ -189,13 +190,23 @@ export default function IFrame({
     }
   }, [contentWindow, titleChangeEventListener, hashChangeEventListener])
 
+  // While a navigation is pending, the router state is transiently inconsistent:
+  // the location already points at the target while the matched params still hold
+  // the previous page, so `src` can be a mix of both. Syncing the iframe with such
+  // a value force-loads the wrong document and bounces the iframe back to the
+  // previous page (BUGS-7690). Only sync once the router has settled.
+  const isNavigationPending = useRouterState({ select: (state) => state.status === 'pending' })
+
   useEffect(() => {
+    if (isNavigationPending) {
+      return
+    }
     const srcWithOrigin = `${window.location.origin}${src}`
     if (sourceRef.current !== srcWithOrigin) {
       iframeRef.current?.contentWindow?.location.replace(srcWithOrigin)
       sourceRef.current = srcWithOrigin
     }
-  }, [src])
+  }, [src, isNavigationPending])
 
   return (
     <iframe

--- a/tests/ui/testPageNavigationRace.spec.ts
+++ b/tests/ui/testPageNavigationRace.spec.ts
@@ -1,0 +1,66 @@
+import { expect } from '@playwright/test'
+import test, { prepareTestSuite } from './base'
+import { BASE_URL } from './helpers'
+
+await prepareTestSuite(test)
+
+/**
+ * Regression test for BUGS-7690:
+ *
+ * When navigating from a page whose URL contains a hash (e.g. config_files.html#axes-limits)
+ * to another page via a link inside the iframe (e.g. limits.html#limitset), the iframe
+ * sometimes "bounces back" to the original page: the target page loads, then the original
+ * page is force-loaded again (at the top, since the new hash doesn't exist there).
+ *
+ * The race only manifests while the route loader is pending, because useLocation() updates
+ * at navigation start while route.useParams() only updates after the loaders resolve.
+ * The loader performs two sequential API calls, so realistic API latency opens the window.
+ * We simulate that latency here by delaying the version API endpoints.
+ */
+
+const API_DELAY_MS = 300
+
+test.beforeEach(async ({ page }) => {
+  // Delay the two version API endpoints awaited by the /$projectName/$version/$ route loader.
+  // Registered after the base mocks, so these take precedence.
+  for (const version of ['3.2.0', 'latest']) {
+    await page.route(`*/**/api/projects/example-project-01/versions/${version}`, async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, API_DELAY_MS))
+      await route.fulfill({ json: '3.2.0' })
+    })
+  }
+})
+
+test('Navigating from a hashed URL to another page must not bounce back (BUGS-7690)', async ({ page }) => {
+  // GIVEN: The user is on a documentation page with an anchor in the URL
+  await page.goto('/example-project-01/3.2.0/index.html#section1')
+
+  const iframe = page.getByTestId('project.documentation.documentationIframe')
+  const iframeDocument = iframe.contentFrame()
+  await expect(iframeDocument.locator('#section1')).toBeInViewport()
+  await expect(page).toHaveURL(`${BASE_URL}/example-project-01/3.2.0/index.html#section1`)
+
+  // Track every page that gets (re-)loaded into the iframe from now on
+  const iframeLoads: string[] = []
+  page.on('request', (request) => {
+    if (request.url().includes('/static/projects/') && request.url().endsWith('.html')) {
+      iframeLoads.push(new URL(request.url()).pathname)
+    }
+  })
+
+  // WHEN: The user clicks a link to another documentation page
+  await iframeDocument.getByRole('link', { name: "Link with href 'examples.html'" }).click()
+
+  // THEN: The examples page must be shown
+  await expect(page).toHaveURL(`${BASE_URL}/example-project-01/3.2.0/examples.html`)
+  await expect(iframeDocument.locator('h1')).toContainText('This is a mocked examples page')
+
+  // AND: It must still be shown after all pending router navigation have settled
+  await page.waitForTimeout(4 * API_DELAY_MS)
+  await expect(page).toHaveURL(`${BASE_URL}/example-project-01/3.2.0/examples.html`)
+  await expect(iframeDocument.locator('h1')).toContainText('This is a mocked examples page')
+
+  // AND: The iframe must have loaded examples.html exactly once and must never
+  // have bounced back to the original page
+  expect(iframeLoads).toStrictEqual(['/static/projects/example-project-01/3.2.0/examples.html'])
+})


### PR DESCRIPTION
Clicking a cross-page link inside the documentation iframe while the URL
contained a hash (e.g. config_files.html#axes-limits -> limits.html#limitset)
sometimes loaded the target page and then bounced back to the original page
at the top.

Root cause: TanStack Router commits a navigation in two phases. The location
store updates as soon as a navigation starts, while the matched route params
only update once the route loader has resolved. During that pending window
(two sequential version API calls per navigation), DocumentationComponent
derives the iframe src from a mix of both sources, yielding a transient
"old page + new hash" URL. The src sync effect in IFrame faithfully executed
that URL via location.replace(), force-loading the previous page again. Its
load event then reported the old page back to the router, cancelling the
in-flight navigation - the two sources of truth chased each other and the
final page depended on which navigation won the race.

Fix: only sync the iframe src while the router is settled. During a pending
navigation the effect skips; once the router commits, it re-runs with a
consistent snapshot of location, params, and loader data.

The regression test reproduces the race deterministically by delaying the
version API endpoints the route loader awaits, mirroring production latency.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
