### PR TITLE
fix(dev): Start uvicorn as a subprocess so its reloader survives

### DIFF
--- a/start_dev.py
+++ b/start_dev.py
@@ -4,10 +4,9 @@
 
 import os
 import subprocess
+import sys
 import time
 from multiprocessing import Process
-
-from uvicorn import run as uvicorn_run
 
 
 def run_vite(port: int = 8090) -> None:
@@ -19,8 +18,29 @@ def run_vite(port: int = 8090) -> None:
 
 
 def run_uvicorn(port: int = 8080) -> None:
-    """Starts the uvicorn development server on the given port."""
-    uvicorn_run(app="vdoc.api:create_app", factory=True, host="localhost", port=port, reload=True, env_file=".env")
+    """Starts the uvicorn development server on the given port.
+
+    Started as a subprocess rather than through ``uvicorn.run``: the reloader spawns the actual server as a further
+    subprocess and hands it the stdin file descriptor of its own process. Inside a ``multiprocessing`` child that
+    descriptor is a ``/dev/null`` replacement which the spawned process does not have, so the server died on startup
+    with ``OSError: [Errno 9] Bad file descriptor`` while the reloader kept running without it.
+    """
+    subprocess.check_call(  # noqa: S603
+        [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "vdoc.api:create_app",
+            "--factory",
+            "--reload",
+            "--host",
+            "localhost",
+            "--port",
+            str(port),
+            "--env-file",
+            ".env",
+        ]
+    )
 
 
 def main() -> None:


### PR DESCRIPTION
## Why

`start_dev.py` brings up vite and uvicorn as two `multiprocessing` children. The uvicorn
half has been running through `uvicorn.run(..., reload=True)`, and in that arrangement the
API never actually comes up:

```
INFO:     Started reloader process [1027374] using StatReload
Traceback (most recent call last):
  File ".venv/lib/python3.14/site-packages/uvicorn/_subprocess.py", line 73, in subprocess_started
OSError: [Errno 9] Bad file descriptor
```

The reloader spawns the real server as a further subprocess and hands it the stdin file
descriptor of its own process. Inside a `multiprocessing` child that descriptor is a
`/dev/null` replacement which the spawned process does not have, so the server dies on
startup while the reloader keeps running without it. The failure is quiet in the worst way:
vite answers on :8090, the reloader looks healthy, and only requests to the API reveal that
nothing is behind it.

## What changed

`run_uvicorn` starts uvicorn as a plain subprocess, which gives the reloader a process whose
stdin it may pass on. `sys.executable -m uvicorn` rather than a bare `uvicorn`, so it is the
interpreter of the active environment either way.

## Verifying

Both versions run against free ports:

| | `main` | this branch |
| --- | --- | --- |
| Reloader | `Started reloader process` | `Started reloader process` |
| Server behind it | `OSError: [Errno 9] Bad file descriptor` | `Started server process`, `Application startup complete` |
| `GET :8080/api/version/` | no server | `"0.24.3"` |
| `GET :8090/api/version/` (vite proxy) | — | `"0.24.3"` |

`mypy`, `ruff format --check` and `ruff check` pass.

## Note for reviewers

This is an independent bugfix with no relation to the two branches stacked on top of it
(`feat/frame-link-handling`, `feat/frame-client-side-navigation`). It sits at the base of
that stack only so the dev setup can be brought up while reviewing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)