### PR TITLE
feat(iframe): Support single-page documentation sites

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ sys.path.insert(0, parent)
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named "sphinx.ext.*") or your custom ones.
-custom_extensions: list[str] = []
+custom_extensions: list[str] = ["sphinxcontrib.mermaid"]
 
 # DO NOT ADD ANY EXTENSIONS TO THIS LIST, USE THE `custom_extensions` list for your extensions
 template_extensions: list[str] = [

--- a/docs/frame_contract.md
+++ b/docs/frame_contract.md
@@ -1,21 +1,166 @@
 # The frame contract
 
-vdoc serves every published documentation site inside an iframe and renders its own user interface
-around it: address bar, page title, version dropdown and color-mode switch. Two names are all a
-documentation framework needs to know in order to take part in that.
+What vdoc and a framed documentation site agree on. Deliberately generator-neutral: nothing here
+names a specific documentation generator, and any of them can implement it.
 
-This page is the source of truth for the contract. It is deliberately generator-neutral -- nothing
-in it is specific to Sphinx, Doxygen or Docusaurus.
+`@voraus/docusaurus-theme` is the reference implementation. The requirement numbers below are shared
+with that theme's own copy of this contract, so a review can cite them across both repositories.
+
+## The signal
+
+Query parameters on the URL the frame is loaded with, and one attribute back. That is the whole wire
+format.
+
+1. vdoc appends **`vdoc-theme=<light|dark>`** -- **unconditionally and on every load**, including the
+   first. It is always a resolved mode, never `system`.
+2. A frame that understands the parameter applies that mode **before its first paint** and sets
+   **`data-vdoc-theme="<mode>"`** on its `<html>` element to declare that it did.
+3. vdoc reads that attribute and nothing else. Without it, it falls back to the legacy conventions it
+   used before this contract existed (`localStorage.darkMode` plus a Tailwind `dark` class, or
+   Doxygen's `*-mode` classes).
+4. vdoc also appends **`vdoc-inset=<px>`**, the horizontal offset it insets its own header content
+   by. Optional in both directions: vdoc may omit it, and a frame may ignore it. See R9.
+
+There is no message channel and no handshake, and deliberately no way for the frame to answer beyond
+that one attribute. Everything below specifies what these names *oblige*, not what else is sent.
+
+```{mermaid}
+sequenceDiagram
+    participant R as Reader
+    participant V as vdoc
+    participant F as Framed document
+    R->>V: opens /proj/1.0/page.html
+    V->>F: loads /static/projects/proj/1.0/page.html?vdoc-theme=dark&vdoc-inset=24
+    Note over F: Inline script in <head> applies the mode<br/>and the inset before the first paint
+    F->>F: sets data-vdoc-theme="dark" on <html>
+    V->>F: reads data-vdoc-theme
+    Note over V: Present and equal to the requested mode,<br/>so no reload is needed
+    R->>V: switches to light
+    V->>F: reloads with ?vdoc-theme=light
+    Note over V: Scroll position is captured before the<br/>reload and restored after it
+```
+
+## Requirements on the frame
+
+### R1 -- Render nothing the host already provides
+
+While `data-vdoc-theme` is set, the frame must not render its own version of anything vdoc supplies
+around it. As of today that is:
+
+| The frame must hide | Because vdoc |
+| --- | --- |
+| Its brand mark or logo | carries the voraus wordmark in its header, directly above the frame |
+| Its color-mode control | owns that switch, and it themes vdoc's own header too, which the frame cannot reach |
+| Its footer with legal links and copyright | renders the imprint, the privacy policy and the copyright below the frame |
+| Its scroll-to-top control | renders one for the scroll position it owns |
+| Its version selector | renders the version picker |
+| Any portal-wide search | provides search across all documentation |
+
+**The rule matters more than the list:** if vdoc shows it, the frame must not show a second one. New
+elements on vdoc's side extend this list without changing the contract.
+
+### R2 -- Hide before the first paint
+
+The hiding must be CSS keyed on the attribute, not a condition evaluated at runtime.
+
+A framework that decides this while rendering decides it *after* the page has been painted, so every
+element appears and then vanishes -- on every single page load. An attribute set ahead of the first
+paint has nothing to flash.
+
+### R3 -- Hide, do not stop rendering
+
+The elements must stay in the document and only be hidden. A reader who opens the site directly,
+without vdoc around it, has no other source for its branding, its color-mode control or its copyright
+line.
+
+This follows from R2 anyway, and it is the reason R1 is a list of CSS rules rather than of conditions.
+
+### R4 -- Do not detect the frame; read the parameter
+
+The frame must not derive "am I framed" from `window.self !== window.top` or any other inspection of
+its surroundings.
+
+Because vdoc appends the parameter unconditionally, its presence *is* the statement that a contract
+host is rendering its own interface around the page. An iframe check is a guess, and a wrong one for
+every other embedding: documentation dropped into a wiki page or a product help panel would lose its
+branding and its only way to change mode, with nothing rendering a replacement.
+
+### R5 -- Never persist the mode
+
+The frame must not write the requested mode to browser storage.
+
+The URL carries it on every load, so storage adds nothing -- and it would leak vdoc's mode into a
+standalone visit to the same origin.
+
+### R6 -- Apply an explicit mode, not a preference
+
+The frame must apply the mode as an explicit light or dark, not as "follow the system".
+
+Left as a system preference, a later change to the operating system's setting overrules vdoc, and the
+frame and the interface around it disagree until the next load.
+
+### R7 -- Carry the parameters through the frame's own navigations
+
+If the frame performs a navigation that discards its document, it must carry `vdoc-theme` over.
+
+Client-side navigation keeps the attribute, because the document is never replaced. A hard navigation
+the frame triggers itself starts a new document, which sees no parameter, declares no attribute, and
+drops back to the legacy path -- a visible flash of the wrong mode with vdoc's own elements duplicated
+inside the frame.
+
+vdoc composes the parameters for the navigations it performs on the frame's behalf.
+
+### R8 -- Paint an opaque background
+
+The frame must paint its own page background in both modes.
+
+Several generators leave the light-mode background transparent and rely on the browser's white
+canvas. An embedded document has no canvas of its own, so vdoc shows through and the page renders
+dark text on a dark surface.
+
+### R9 -- Take the host's content inset from `vdoc-inset`
+
+Having hidden its own logo (R1), the frame has nothing left to position its remaining header content
+against. Lining that content up with vdoc's header requires knowing where vdoc's header content
+starts, and only vdoc knows that.
+
+So vdoc sends it: **`vdoc-inset=<px>`**, an integer in CSS pixels. A frame that implements this must
+apply it as its own horizontal header padding while framed, and must fall back to its normal layout
+when the parameter is absent.
+
+Both sides may skip it. A frame that ignores it is merely misaligned, not broken.
+
+**Why a parameter rather than a number written down here.** vdoc keeps every published version
+forever. A fixed number would be baked into each site's stylesheet at build time, so vdoc could never
+change its own gutter again without stranding every site published before the change. A parameter
+arrives on every load, so a snapshot built years ago follows vdoc's current layout. vdoc measures the
+value from its own header rather than hardcoding it, for the same reason.
+
+**What does not work, so nobody tries it again.** Aligning the frame's header content to the frame's
+*own* page content: generators center their content column once the viewport is wider than it, so the
+content drifts away from the fixed sidebar edge a header rule can track. Measured in Docusaurus, the
+content sits at 316px in a 1400px viewport and at 706px in a 2400px one, while the header rule stays
+at 316px either way -- leaving the header content stranded in the gap.
+
+### R10 -- Do not route links from their DOM `href`
+
+The frame's router must not decide where a link goes by reading `anchor.href`.
+
+vdoc rewrites the `href` of every anchor in the framed document to its readable form, so that
+hovering, copying and the browser's own new-tab shortcuts name the page rather than the file behind
+it. A component-based router that carries its target in a prop -- the usual case -- is unaffected. A
+router that reads `anchor.href` and compares it against its own base path will not recognize its own
+links, and every one of them will fall through to a full document load.
 
 ## Why a page has two addresses
 
-vdoc's backend serves the published files under `/static/projects/<project>/<version>/…` and answers
-the bare `/<project>/<version>/…` with its own single-page application, which frames the files.
+The requirement above follows from this, so it is worth stating once.
 
-The prefix is not decoration, it is what makes relative links work. A relative link inside
-`/static/projects/proj/1.0/page.html` resolves to `/static/projects/proj/1.0/other.html` and stays
-inside the file namespace. Without a namespace of its own, a click inside the frame would load
-vdoc's application *into* the frame, recursively.
+vdoc's backend serves the published files under `/static/projects/<project>/<version>/…` and answers
+the bare `/<project>/<version>/…` with its own application, which frames those files. The prefix is
+not decoration: a relative link inside `/static/projects/proj/1.0/page.html` resolves to
+`/static/projects/proj/1.0/other.html` and stays inside the file namespace. Without a namespace of its
+own, a click inside the frame would load vdoc's application *into* the frame, recursively.
 
 So every page has two addresses, and mapping between them is a pure function in both directions
 (`toReadableHref` and `toFrameHref` in `src/ui/helpers/RouteHelpers.ts`):
@@ -25,56 +170,8 @@ So every page has two addresses, and mapping between them is a pure function in 
 | The file, loaded into the frame | `/static/projects/proj/1.0/page.html` |
 | The readable one, in vdoc's address bar and on every link | `/proj/1.0/page.html` |
 
-## The contract
-
-Three statements, and nothing else. No `postMessage`, no handshake.
-
-1. vdoc appends **`vdoc-theme=<light|dark>`** to the URL it loads the frame with -- unconditionally
-   and on every load, including the first.
-2. A frame that understands the parameter applies that mode **before its first paint** and sets
-   **`data-vdoc-theme="<mode>"`** on its `<html>` element to say so.
-3. vdoc reads that attribute and nothing else. If it is absent, vdoc falls back to reaching into the
-   framed document the way it always has (`localStorage.darkMode` plus a Tailwind `dark` class, or
-   Doxygen's `*-mode` classes).
-
-```{mermaid}
-sequenceDiagram
-    participant R as Reader
-    participant V as vdoc
-    participant F as Framed document
-    R->>V: opens /proj/1.0/page.html
-    V->>F: loads /static/projects/proj/1.0/page.html?vdoc-theme=dark
-    Note over F: Pre-body script reads the parameter and<br/>applies the mode before the first paint
-    F->>F: sets data-vdoc-theme="dark" on <html>
-    V->>F: reads data-vdoc-theme
-    Note over V: Present and equal to the requested mode,<br/>so no reload is needed
-    R->>V: switches to light
-    V->>F: reloads with ?vdoc-theme=light
-    Note over V: Scroll position is captured before the<br/>reload and restored after it
-```
-
-Because vdoc appends the parameter unconditionally, a frame that ignores it is unaffected -- an
-unknown query parameter is inert. That is why no generator detection is needed anywhere.
-
-### Applying the mode before the first paint
-
-Applying it later is visible as a flash of the wrong mode. A framework therefore has to do this in a
-blocking inline script in `<head>`, before any styled content, rather than in whatever runs after
-hydration. Reading the parameter from `window.location.search` is enough; nothing has to be stored.
-
-A stored preference cannot replace the parameter, because on a reader's very first visit there is
-nothing stored yet -- which is precisely the case the parameter fixes.
-
-## The parameter also means "a host renders the surrounding interface"
-
-Since vdoc appends the parameter on every load, its presence is proof that a contract-aware host
-frames the page. A framework should therefore hide the parts of its own user interface that vdoc
-already shows in its header -- typically the site logo and the color-mode switch -- keyed on
-`[data-vdoc-theme]`.
-
-Key it on that attribute, not on `window.self !== window.top`. Being framed is not the same as being
-framed *by vdoc*: documentation embedded in some other page would lose its branding and its mode
-switch with nothing put in their place.
+vdoc's own parameters never appear in the readable form. They are requests to the frame, not part of
+a page's address.
 
 ## What vdoc does around the frame
 
@@ -86,12 +183,8 @@ listens for `popstate`, because a single-page generator swaps pages without a do
 neither method emits an event. That is how vdoc's address bar follows client-side routing. It also
 watches the framed `<head>`, since a client-side router sets the title after navigating.
 
-**Links.** On each document load vdoc rewrites the `href` of every anchor to the readable form, so
-that hovering, copying and the browser's own new-tab shortcuts name the page rather than the file.
-Navigation resolves the address back, so a link whose `href` a framework restores on re-render still
-leads to the same place. Anchors carrying `download` are left alone.
-
-Clicks are handled by two delegated listeners on the framed document, never per anchor:
+**Links.** Clicks are handled by two delegated listeners on the framed document, never per anchor, so
+that links rendered after the document loaded are covered too:
 
 ```{mermaid}
 flowchart TD
@@ -104,25 +197,20 @@ flowchart TD
     P -->|no| F[vdoc navigates the frame]
 ```
 
-The consequence for a framework: **routing a link must not depend on reading its DOM `href`**, since
-vdoc has rewritten it. A component-based router that carries its target in a prop -- the usual case
--- is unaffected. A router that reads `anchor.href` and compares it against its own base path will
-not recognize its own links.
-
 ## Adopting the contract
 
-A framework needs one inline script in `<head>` and one CSS rule:
+For a framework that has none of this yet, in order:
 
-1. Read `vdoc-theme` from `window.location.search`.
-2. If present, apply that mode the way the framework applies modes -- its `data-theme` attribute, its
-   class, its storage key, whatever it already uses -- and do it before the first paint.
-3. Set `data-vdoc-theme` on `<html>` to the mode that was applied. Its value is what vdoc compares
-   against, so it has to name the mode actually in effect, not the mode requested.
-4. Hide the logo and the color-mode switch under `[data-vdoc-theme]`.
-5. Make sure link routing does not read the DOM `href`.
+1. One inline script in `<head>`: read `vdoc-theme` and `vdoc-inset` from `window.location.search`,
+   apply the mode the way the framework already applies modes, apply the inset as horizontal header
+   padding, and set `data-vdoc-theme` to the mode actually in effect (R2, R6, R9).
+2. CSS keyed on `[data-vdoc-theme]` that hides everything in R1 -- hiding it, not omitting it (R3).
+3. Make sure the mode is not written to storage (R5) and that no code asks whether it is framed (R4).
+4. Give the page an opaque background in both modes (R8).
+5. Carry `vdoc-theme` through any hard navigation the framework performs itself (R7).
+6. Check that link routing does not read the DOM `href` (R10).
 
-Nothing else is required, and nothing may be added: the contract is these two names. Resist growing
-it into a message-passing protocol -- the query parameter already does the job, and every addition
-is something every future framework has to implement.
-
-`@voraus/docusaurus-theme` implements the whole of it in roughly 30 lines.
+Nothing else is required, and nothing may be added: the contract is these two parameters and one
+attribute. Resist growing it into a message-passing protocol -- a value on the URL, applied before the
+first paint, already does the job, and every addition is something every future framework has to
+implement.

--- a/docs/frame_contract.md
+++ b/docs/frame_contract.md
@@ -1,0 +1,128 @@
+# The frame contract
+
+vdoc serves every published documentation site inside an iframe and renders its own user interface
+around it: address bar, page title, version dropdown and color-mode switch. Two names are all a
+documentation framework needs to know in order to take part in that.
+
+This page is the source of truth for the contract. It is deliberately generator-neutral -- nothing
+in it is specific to Sphinx, Doxygen or Docusaurus.
+
+## Why a page has two addresses
+
+vdoc's backend serves the published files under `/static/projects/<project>/<version>/…` and answers
+the bare `/<project>/<version>/…` with its own single-page application, which frames the files.
+
+The prefix is not decoration, it is what makes relative links work. A relative link inside
+`/static/projects/proj/1.0/page.html` resolves to `/static/projects/proj/1.0/other.html` and stays
+inside the file namespace. Without a namespace of its own, a click inside the frame would load
+vdoc's application *into* the frame, recursively.
+
+So every page has two addresses, and mapping between them is a pure function in both directions
+(`toReadableHref` and `toFrameHref` in `src/ui/helpers/RouteHelpers.ts`):
+
+| | Address |
+| --- | --- |
+| The file, loaded into the frame | `/static/projects/proj/1.0/page.html` |
+| The readable one, in vdoc's address bar and on every link | `/proj/1.0/page.html` |
+
+## The contract
+
+Three statements, and nothing else. No `postMessage`, no handshake.
+
+1. vdoc appends **`vdoc-theme=<light|dark>`** to the URL it loads the frame with -- unconditionally
+   and on every load, including the first.
+2. A frame that understands the parameter applies that mode **before its first paint** and sets
+   **`data-vdoc-theme="<mode>"`** on its `<html>` element to say so.
+3. vdoc reads that attribute and nothing else. If it is absent, vdoc falls back to reaching into the
+   framed document the way it always has (`localStorage.darkMode` plus a Tailwind `dark` class, or
+   Doxygen's `*-mode` classes).
+
+```{mermaid}
+sequenceDiagram
+    participant R as Reader
+    participant V as vdoc
+    participant F as Framed document
+    R->>V: opens /proj/1.0/page.html
+    V->>F: loads /static/projects/proj/1.0/page.html?vdoc-theme=dark
+    Note over F: Pre-body script reads the parameter and<br/>applies the mode before the first paint
+    F->>F: sets data-vdoc-theme="dark" on <html>
+    V->>F: reads data-vdoc-theme
+    Note over V: Present and equal to the requested mode,<br/>so no reload is needed
+    R->>V: switches to light
+    V->>F: reloads with ?vdoc-theme=light
+    Note over V: Scroll position is captured before the<br/>reload and restored after it
+```
+
+Because vdoc appends the parameter unconditionally, a frame that ignores it is unaffected -- an
+unknown query parameter is inert. That is why no generator detection is needed anywhere.
+
+### Applying the mode before the first paint
+
+Applying it later is visible as a flash of the wrong mode. A framework therefore has to do this in a
+blocking inline script in `<head>`, before any styled content, rather than in whatever runs after
+hydration. Reading the parameter from `window.location.search` is enough; nothing has to be stored.
+
+A stored preference cannot replace the parameter, because on a reader's very first visit there is
+nothing stored yet -- which is precisely the case the parameter fixes.
+
+## The parameter also means "a host renders the surrounding interface"
+
+Since vdoc appends the parameter on every load, its presence is proof that a contract-aware host
+frames the page. A framework should therefore hide the parts of its own user interface that vdoc
+already shows in its header -- typically the site logo and the color-mode switch -- keyed on
+`[data-vdoc-theme]`.
+
+Key it on that attribute, not on `window.self !== window.top`. Being framed is not the same as being
+framed *by vdoc*: documentation embedded in some other page would lose its branding and its mode
+switch with nothing put in their place.
+
+## What vdoc does around the frame
+
+Descriptive, not normative -- a framework does not have to do anything for this. It is here so that
+the behavior is not mistaken for interference.
+
+**Navigation.** vdoc wraps `history.pushState` and `history.replaceState` on the framed window and
+listens for `popstate`, because a single-page generator swaps pages without a document load and
+neither method emits an event. That is how vdoc's address bar follows client-side routing. It also
+watches the framed `<head>`, since a client-side router sets the title after navigating.
+
+**Links.** On each document load vdoc rewrites the `href` of every anchor to the readable form, so
+that hovering, copying and the browser's own new-tab shortcuts name the page rather than the file.
+Navigation resolves the address back, so a link whose `href` a framework restores on re-render still
+leads to the same place. Anchors carrying `download` are left alone.
+
+Clicks are handled by two delegated listeners on the framed document, never per anchor:
+
+```{mermaid}
+flowchart TD
+    C[Click on a link in the frame] --> M{"Modified click<br/>or download?"}
+    M -->|yes| B[Left to the browser]
+    M -->|no| O{"Other origin, other project<br/>or target=_blank?"}
+    O -->|yes| N["vdoc opens the readable<br/>address in a new tab"]
+    O -->|no| P{"Did the framework call<br/>preventDefault()?"}
+    P -->|yes| R[The framework routes it itself]
+    P -->|no| F[vdoc navigates the frame]
+```
+
+The consequence for a framework: **routing a link must not depend on reading its DOM `href`**, since
+vdoc has rewritten it. A component-based router that carries its target in a prop -- the usual case
+-- is unaffected. A router that reads `anchor.href` and compares it against its own base path will
+not recognize its own links.
+
+## Adopting the contract
+
+A framework needs one inline script in `<head>` and one CSS rule:
+
+1. Read `vdoc-theme` from `window.location.search`.
+2. If present, apply that mode the way the framework applies modes -- its `data-theme` attribute, its
+   class, its storage key, whatever it already uses -- and do it before the first paint.
+3. Set `data-vdoc-theme` on `<html>` to the mode that was applied. Its value is what vdoc compares
+   against, so it has to name the mode actually in effect, not the mode requested.
+4. Hide the logo and the color-mode switch under `[data-vdoc-theme]`.
+5. Make sure link routing does not read the DOM `href`.
+
+Nothing else is required, and nothing may be added: the contract is these two names. Resist growing
+it into a message-passing protocol -- the query parameter already does the job, and every addition
+is something every future framework has to implement.
+
+`@voraus/docusaurus-theme` implements the whole of it in roughly 30 lines.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ vdoc
 getting_started
 configuration
 plugins
+frame_contract
 development
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ test = [
 doc = [
     {include-group = "doc-template"},
     # Add additional documentation dependencies below this line
+    "sphinxcontrib-mermaid~=2.1",
 ]
 build = [
     {include-group = "build-template"},

--- a/src/ui/__tests__/helpers/iframeHelpers.test.ts
+++ b/src/ui/__tests__/helpers/iframeHelpers.test.ts
@@ -305,3 +305,40 @@ describe('parseIFrameHref', () => {
     expect(result).toEqual(expected)
   })
 })
+
+describe('parseIFrameHref and the color mode parameter', () => {
+  let iframeRef: React.RefObject<HTMLIFrameElement | null>
+
+  beforeEach(() => {
+    iframeRef = { current: document.createElement('iframe') }
+  })
+
+  test.each([
+    {
+      description: 'strips the vdoc-theme parameter vdoc appends for the frame itself',
+      href: 'http://localhost:3000/static/projects/proj/1.0.0/page.html?vdoc-theme=dark',
+      expectedSearch: new URLSearchParams(''),
+      expectedHash: '',
+    },
+    {
+      description: 'strips vdoc-theme while preserving the other search parameters and the hash',
+      href: 'http://localhost:3000/static/projects/proj/1.0.0/page.html?q=search&vdoc-theme=light&filter=all#foo',
+      expectedSearch: new URLSearchParams('q=search&filter=all'),
+      expectedHash: 'foo',
+    },
+  ])('$description', ({ href, expectedSearch, expectedHash }) => {
+    // GIVEN: A frame sitting on an address vdoc composed for it
+    Object.defineProperty(iframeRef.current, 'contentDocument', {
+      value: { location: { href }, title: 'Page' },
+      configurable: true,
+    })
+
+    // WHEN: Reporting where the frame is
+    const result = parseIFrameHref(iframeRef)
+
+    // THEN: vdoc's own request does not reach its address bar, where the next compose would append
+    // it a second time
+    expect(result?.search).toEqual(expectedSearch)
+    expect(result?.hash).toBe(expectedHash)
+  })
+})

--- a/src/ui/__tests__/helpers/routeHelpers.test.ts
+++ b/src/ui/__tests__/helpers/routeHelpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import {
+  composeIFrameSrc,
   normalizeIFrameSrc,
   sanitizeDocuUri,
   stripFramePrefix,
@@ -321,6 +322,16 @@ describe('normalizeIFrameSrc', () => {
       expected: 'http://localhost:3000/static/projects/proj/1.0.0/page.html?q=search#section',
     },
     {
+      description: 'removes the vdoc-theme parameter, which is never part of a page identity',
+      src: '/static/projects/proj/1.0.0/page.html?vdoc-theme=dark',
+      expected: 'http://localhost:3000/static/projects/proj/1.0.0/page.html',
+    },
+    {
+      description: 'removes vdoc-theme from among other parameters, keeping the hash',
+      src: '/static/projects/proj/1.0.0/page.html?q=search&vdoc-theme=dark#section',
+      expected: 'http://localhost:3000/static/projects/proj/1.0.0/page.html?q=search#section',
+    },
+    {
       description: 'removes a trailing slash, so a page published as a directory has one identity',
       src: '/static/projects/proj/1.0.0/guide/',
       expected: 'http://localhost:3000/static/projects/proj/1.0.0/guide',
@@ -355,5 +366,100 @@ describe('normalizeIFrameSrc', () => {
     expect(normalizeIFrameSrc('/static/projects/proj/1.0.0/guide', origin)).not.toBe(
       normalizeIFrameSrc('/static/projects/proj/1.0.0/api', origin)
     )
+  })
+})
+
+describe('composeIFrameSrc', () => {
+  const origin = 'http://localhost:3000'
+
+  test.each([
+    {
+      description: 'appends the color mode to a plain source',
+      src: '/static/projects/proj/1.0.0/page.html',
+      mode: 'dark' as const,
+      expected: 'http://localhost:3000/static/projects/proj/1.0.0/page.html?vdoc-theme=dark',
+    },
+    {
+      description: 'appends the color mode to a source that already carries a query',
+      src: '/static/projects/proj/1.0.0/page.html?q=search',
+      mode: 'light' as const,
+      expected: 'http://localhost:3000/static/projects/proj/1.0.0/page.html?q=search&vdoc-theme=light',
+    },
+    {
+      description: 'keeps the hash last when the source carries a query and a hash',
+      src: '/static/projects/proj/1.0.0/page.html?q=search#section',
+      mode: 'dark' as const,
+      expected: 'http://localhost:3000/static/projects/proj/1.0.0/page.html?q=search&vdoc-theme=dark#section',
+    },
+    {
+      description: 'keeps the hash last when the source carries a hash only',
+      src: '/static/projects/proj/1.0.0/page.html#section',
+      mode: 'light' as const,
+      expected: 'http://localhost:3000/static/projects/proj/1.0.0/page.html?vdoc-theme=light#section',
+    },
+    {
+      description: 'replaces a vdoc-theme already present instead of appending a second one',
+      src: '/static/projects/proj/1.0.0/page.html?vdoc-theme=light&q=search',
+      mode: 'dark' as const,
+      expected: 'http://localhost:3000/static/projects/proj/1.0.0/page.html?vdoc-theme=dark&q=search',
+    },
+    {
+      description: 'keeps a trailing slash, which is part of the address to request',
+      src: '/static/projects/proj/1.0.0/guide/',
+      mode: 'dark' as const,
+      expected: 'http://localhost:3000/static/projects/proj/1.0.0/guide/?vdoc-theme=dark',
+    },
+  ])('$description', ({ src, mode, expected }) => {
+    expect(composeIFrameSrc(src, mode, origin)).toBe(expected)
+  })
+
+  test('is stable when applied repeatedly', () => {
+    // GIVEN: A source that has already been composed once
+    const composed = composeIFrameSrc('/static/projects/proj/1.0.0/page.html?q=search', 'dark', origin)
+
+    // WHEN/THEN: Composing again for the same mode changes nothing, so a navigation that passes
+    // through it twice cannot accumulate parameters
+    expect(composeIFrameSrc(composed, 'dark', origin)).toBe(composed)
+  })
+
+  test('the composed source has the same identity as the one it was composed from', () => {
+    // GIVEN: A source vdoc composed for the frame
+    const src = '/static/projects/proj/1.0.0/page.html?q=search#section'
+    const loaded = composeIFrameSrc(src, 'dark', origin)
+
+    // WHEN/THEN: Both sides of the comparison the sync effect makes agree, so a frame sitting on
+    // exactly the address it was given never looks stale and is never force-loaded
+    expect(normalizeIFrameSrc(loaded, origin)).toBe(normalizeIFrameSrc(src, origin))
+  })
+})
+
+describe('toReadableHref and the color mode parameter', () => {
+  const origin = 'http://localhost:3000'
+
+  test.each([
+    {
+      description: 'drops the parameter vdoc appended for the frame',
+      href: 'http://localhost:3000/static/projects/proj/1.0.0/page.html?vdoc-theme=light',
+      expected: 'http://localhost:3000/proj/1.0.0/page.html',
+    },
+    {
+      description: 'drops it while keeping a query the documentation itself uses',
+      href: 'http://localhost:3000/static/projects/proj/1.0.0/page.html?q=search&vdoc-theme=dark',
+      expected: 'http://localhost:3000/proj/1.0.0/page.html?q=search',
+    },
+    {
+      description: 'drops it from a fragment-only link, which resolves against the whole document address',
+      href: 'http://localhost:3000/static/projects/proj/1.0.0/?vdoc-theme=light#section1',
+      expected: 'http://localhost:3000/proj/1.0.0/#section1',
+    },
+    {
+      description: 'drops it from a bare fragment link',
+      href: 'http://localhost:3000/static/projects/proj/1.0.0/?vdoc-theme=dark#',
+      expected: 'http://localhost:3000/proj/1.0.0/#',
+    },
+  ])('$description', ({ href, expected }) => {
+    // GIVEN/WHEN/THEN: What the reader hovers, copies and opens in a new tab is the address vdoc's
+    // own router answers - never the request vdoc made to the frame
+    expect(toReadableHref(href, origin)).toBe(expected)
   })
 })

--- a/src/ui/__tests__/helpers/routeHelpers.test.ts
+++ b/src/ui/__tests__/helpers/routeHelpers.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'vitest'
-import { sanitizeDocuUri, stripFramePrefix, toFrameHref, toReadableHref } from '../../helpers/RouteHelpers'
+import {
+  normalizeIFrameSrc,
+  sanitizeDocuUri,
+  stripFramePrefix,
+  toFrameHref,
+  toReadableHref,
+} from '../../helpers/RouteHelpers'
 
 describe('sanitizeDocuUri', () => {
   test('sanitizes valid uris as expected', () => {
@@ -292,5 +298,62 @@ describe('sanitizeDocuUri and toReadableHref agree where they must', () => {
     // WHEN/THEN: Both keep the page where it is
     expect(sanitizeDocuUri(`${origin}${path}`)._splat).toBe('static/projects/deep.html')
     expect(toReadableHref(path, origin)).toBe(`${origin}/proj/1.0.0/static/projects/deep.html`)
+  })
+})
+
+describe('normalizeIFrameSrc', () => {
+  const origin = 'http://localhost:3000'
+
+  test.each([
+    {
+      description: 'makes a relative source absolute',
+      src: '/static/projects/proj/1.0.0/page.html',
+      expected: 'http://localhost:3000/static/projects/proj/1.0.0/page.html',
+    },
+    {
+      description: 'leaves an absolute source alone',
+      src: 'http://localhost:3000/static/projects/proj/1.0.0/page.html',
+      expected: 'http://localhost:3000/static/projects/proj/1.0.0/page.html',
+    },
+    {
+      description: 'preserves an existing query and hash',
+      src: '/static/projects/proj/1.0.0/page.html?q=search#section',
+      expected: 'http://localhost:3000/static/projects/proj/1.0.0/page.html?q=search#section',
+    },
+    {
+      description: 'removes a trailing slash, so a page published as a directory has one identity',
+      src: '/static/projects/proj/1.0.0/guide/',
+      expected: 'http://localhost:3000/static/projects/proj/1.0.0/guide',
+    },
+    {
+      description: 'removes a trailing slash while keeping the query and the hash',
+      src: '/static/projects/proj/1.0.0/guide/?q=search#section',
+      expected: 'http://localhost:3000/static/projects/proj/1.0.0/guide?q=search#section',
+    },
+    {
+      description: 'keeps the root slash, which is the whole path',
+      src: '/',
+      expected: 'http://localhost:3000/',
+    },
+  ])('$description', ({ src, expected }) => {
+    expect(normalizeIFrameSrc(src, origin)).toBe(expected)
+  })
+
+  test('a page reached through a redirect that adds a trailing slash keeps its identity', () => {
+    // GIVEN: The address vdoc asked for, and the one the frame ended up on after the normalization
+    // a generator that publishes pages as directories performs
+    const requested = '/static/projects/proj/1.0.0/guide'
+    const reached = 'http://localhost:3000/static/projects/proj/1.0.0/guide/'
+
+    // WHEN/THEN: They are the same page, so the frame is not force-loaded back and forth forever
+    expect(normalizeIFrameSrc(reached, origin)).toBe(normalizeIFrameSrc(requested, origin))
+  })
+
+  test('two different pages keep two identities', () => {
+    // GIVEN: Two pages that differ in more than a trailing slash
+    // WHEN/THEN: They stay distinguishable, or the frame would never be loaded for the second one
+    expect(normalizeIFrameSrc('/static/projects/proj/1.0.0/guide', origin)).not.toBe(
+      normalizeIFrameSrc('/static/projects/proj/1.0.0/api', origin)
+    )
   })
 })

--- a/src/ui/__tests__/helpers/routeHelpers.test.ts
+++ b/src/ui/__tests__/helpers/routeHelpers.test.ts
@@ -410,22 +410,22 @@ describe('composeIFrameSrc', () => {
       expected: 'http://localhost:3000/static/projects/proj/1.0.0/guide/?vdoc-theme=dark',
     },
   ])('$description', ({ src, mode, expected }) => {
-    expect(composeIFrameSrc(src, mode, origin)).toBe(expected)
+    expect(composeIFrameSrc(src, { mode }, origin)).toBe(expected)
   })
 
   test('is stable when applied repeatedly', () => {
     // GIVEN: A source that has already been composed once
-    const composed = composeIFrameSrc('/static/projects/proj/1.0.0/page.html?q=search', 'dark', origin)
+    const composed = composeIFrameSrc('/static/projects/proj/1.0.0/page.html?q=search', { mode: 'dark' }, origin)
 
     // WHEN/THEN: Composing again for the same mode changes nothing, so a navigation that passes
     // through it twice cannot accumulate parameters
-    expect(composeIFrameSrc(composed, 'dark', origin)).toBe(composed)
+    expect(composeIFrameSrc(composed, { mode: 'dark' }, origin)).toBe(composed)
   })
 
   test('the composed source has the same identity as the one it was composed from', () => {
     // GIVEN: A source vdoc composed for the frame
     const src = '/static/projects/proj/1.0.0/page.html?q=search#section'
-    const loaded = composeIFrameSrc(src, 'dark', origin)
+    const loaded = composeIFrameSrc(src, { mode: 'dark' }, origin)
 
     // WHEN/THEN: Both sides of the comparison the sync effect makes agree, so a frame sitting on
     // exactly the address it was given never looks stale and is never force-loaded
@@ -461,5 +461,61 @@ describe('toReadableHref and the color mode parameter', () => {
     // GIVEN/WHEN/THEN: What the reader hovers, copies and opens in a new tab is the address vdoc's
     // own router answers - never the request vdoc made to the frame
     expect(toReadableHref(href, origin)).toBe(expected)
+  })
+})
+
+describe('composeIFrameSrc and the content inset', () => {
+  const origin = 'http://localhost:3000'
+
+  test.each([
+    {
+      description: 'sends the inset next to the mode',
+      params: { mode: 'dark' as const, inset: 24 },
+      expected: 'http://localhost:3000/static/projects/proj/1.0.0/p.html?vdoc-theme=dark&vdoc-inset=24',
+    },
+    {
+      description: 'rounds a fractional measurement, since the parameter is whole pixels',
+      params: { mode: 'light' as const, inset: 23.6 },
+      expected: 'http://localhost:3000/static/projects/proj/1.0.0/p.html?vdoc-theme=light&vdoc-inset=24',
+    },
+    {
+      description: 'omits the inset while it has not been measured',
+      params: { mode: 'dark' as const, inset: 0 },
+      expected: 'http://localhost:3000/static/projects/proj/1.0.0/p.html?vdoc-theme=dark',
+    },
+    {
+      description: 'omits the inset when none is given at all',
+      params: { mode: 'dark' as const },
+      expected: 'http://localhost:3000/static/projects/proj/1.0.0/p.html?vdoc-theme=dark',
+    },
+  ])('$description', ({ params, expected }) => {
+    expect(composeIFrameSrc('/static/projects/proj/1.0.0/p.html', params, origin)).toBe(expected)
+  })
+
+  test('a stale inset is replaced rather than added a second time', () => {
+    // GIVEN: An address the frame is already on, which carries the inset vdoc sent last time
+    const current = 'http://localhost:3000/static/projects/proj/1.0.0/p.html?vdoc-theme=dark&vdoc-inset=16'
+
+    // WHEN/THEN: Composing again for a wider viewport carries exactly one inset
+    expect(composeIFrameSrc(current, { mode: 'dark', inset: 24 }, origin)).toBe(
+      'http://localhost:3000/static/projects/proj/1.0.0/p.html?vdoc-theme=dark&vdoc-inset=24'
+    )
+  })
+
+  test('the inset is not part of a page identity', () => {
+    // GIVEN: The same page, framed at two different viewport widths
+    const narrow = composeIFrameSrc('/static/projects/proj/1.0.0/p.html', { mode: 'dark', inset: 16 }, origin)
+    const wide = composeIFrameSrc('/static/projects/proj/1.0.0/p.html', { mode: 'dark', inset: 24 }, origin)
+
+    // WHEN/THEN: Resizing the window does not make the frame look stale, which would reload it
+    expect(normalizeIFrameSrc(wide, origin)).toBe(normalizeIFrameSrc(narrow, origin))
+  })
+
+  test('the inset never reaches a readable address', () => {
+    // GIVEN: A fragment link inside a framed page, which resolves against the whole document address
+    const inFrame = 'http://localhost:3000/static/projects/proj/1.0.0/?vdoc-theme=dark&vdoc-inset=24#section1'
+
+    // WHEN/THEN: What the reader hovers and copies is free of both of vdoc's parameters
+    expect(toReadableHref(inFrame, origin)).toBe('http://localhost:3000/proj/1.0.0/#section1')
   })
 })

--- a/src/ui/components/DocumentationComponent.tsx
+++ b/src/ui/components/DocumentationComponent.tsx
@@ -1,7 +1,7 @@
 import { getRouteApi, useLocation, useRouter } from '@tanstack/react-router'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
-import type { IFrameLocation } from '../helpers/IFrame'
+import type { IFrameHistoryMode, IFrameLocation } from '../helpers/IFrame'
 import testIDs from '../interfacesAndTypes/testIDs'
 import { DeprecatedVersionBanner } from './DeprecatedVersionBanner'
 import IFrame from './IFrame'
@@ -86,6 +86,14 @@ function DocuIFrame(props: DocuIFramePropsI) {
     setError(new Error("Whoops! This page doesn't seem to exist..."))
   }
 
+  // Kept in a ref rather than in state: `report()` in `IFrame` always sets it before the state
+  // updates that trigger the navigation below, and it must not trigger a navigation of its own.
+  const historyModeRef = useRef<IFrameHistoryMode>('push')
+
+  const iFrameHistoryModeChanged = (historyMode: IFrameHistoryMode): void => {
+    historyModeRef.current = historyMode
+  }
+
   useEffect(() => {
     // Throwing the error in a useEffect to ensure it is caught by the error component of tanstack router.
     if (error) {
@@ -115,6 +123,10 @@ function DocuIFrame(props: DocuIFramePropsI) {
         ...searchObject,
       }),
       hash: iframeState.hash.trim() !== '' ? iframeState.hash : '',
+      // A page the frame reached through client-side navigation already has a session history
+      // entry of the frame's own making; adding a second one here would make the back button need
+      // two clicks per page.
+      replace: historyModeRef.current === 'replace',
     })
   }, [error, iframeState.name, props.version, iframeState.page, iframeState.hash, iframeState.search, router])
 
@@ -130,6 +142,7 @@ function DocuIFrame(props: DocuIFramePropsI) {
         onSearchChanged={iFrameSearchChanged}
         onTitleChanged={iframeTitleChanged}
         onNotFound={iFrameNotFound}
+        onHistoryModeChanged={iFrameHistoryModeChanged}
       />
     </div>
   )

--- a/src/ui/components/DocumentationComponent.tsx
+++ b/src/ui/components/DocumentationComponent.tsx
@@ -7,11 +7,14 @@ import { DeprecatedVersionBanner } from './DeprecatedVersionBanner'
 import IFrame from './IFrame'
 
 const route = getRouteApi('/$projectName/$version/$')
+// The resolved version belongs to the project version, not to the page, so it is loaded one route
+// up - which is what keeps a page change from re-running that lookup.
+const versionRoute = getRouteApi('/$projectName/$version')
 
 export function DocumentationComponent() {
   const location = useLocation()
   const { projectName, _splat } = route.useParams()
-  const [resolvedVersion, latestVersion] = route.useLoaderData()
+  const [resolvedVersion, latestVersion] = versionRoute.useLoaderData()
 
   const iframeProps = useMemo(
     () => ({

--- a/src/ui/components/IFrame.tsx
+++ b/src/ui/components/IFrame.tsx
@@ -8,8 +8,8 @@ import { useRouterState } from '@tanstack/react-router'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useIFrameScroll } from '../contexts/IFrameScrollContext'
 import { hookFramedDocument } from '../helpers/FramedDocument'
-import { parseIFrameHref, toggleDocumentationColorScheme } from '../helpers/IFrame'
-import { sanitizeDocuUri, toFrameHref, toReadableHref } from '../helpers/RouteHelpers'
+import { type IFrameHistoryMode, parseIFrameHref, toggleDocumentationColorScheme } from '../helpers/IFrame'
+import { normalizeIFrameSrc, sanitizeDocuUri, toFrameHref, toReadableHref } from '../helpers/RouteHelpers'
 import type { EffectiveColorMode } from '../interfacesAndTypes/ColorModes'
 import { testIDs } from '../interfacesAndTypes/testIDs'
 
@@ -20,6 +20,7 @@ interface Props {
   onSearchChanged: (search: URLSearchParams) => void
   onTitleChanged: (title: string) => void
   onNotFound: () => void
+  onHistoryModeChanged: (mode: IFrameHistoryMode) => void
 }
 
 export default function IFrame({
@@ -29,6 +30,7 @@ export default function IFrame({
   onSearchChanged,
   onTitleChanged,
   onNotFound,
+  onHistoryModeChanged,
 }: Props) {
   const { colorScheme } = useColorScheme()
   const { setScrollY } = useIFrameScroll()
@@ -37,6 +39,11 @@ export default function IFrame({
   const [contentWindow, setContentWindow] = useState<Window | null>()
 
   const currentProjectName = useMemo(() => sanitizeDocuUri(src).projectName, [src])
+
+  /** Last page reported, so the scroll position is only reset when the page actually changed. */
+  const reportedPageRef = useRef<string | null>(null)
+  /** Last title reported, so a title arriving late is only forwarded when it is a change. */
+  const reportedTitleRef = useRef<string | null>(null)
 
   const setDarkMode = useCallback((mode: EffectiveColorMode) => {
     toggleDocumentationColorScheme(iframeRef, mode)
@@ -72,6 +79,43 @@ export default function IFrame({
       contentWindow.addEventListener('scroll', handleScroll, { passive: true })
     }
 
+    /**
+     * Tell vdoc's own interface where the frame currently is.
+     *
+     * Called for every document load and, through the hooks installed below, for every navigation
+     * the frame performs on its own.
+     */
+    const report = (historyMode: IFrameHistoryMode): void => {
+      const frameLocation = parseIFrameHref(iframeRef)
+      if (frameLocation == null) {
+        return
+      }
+
+      // Before `onPageChanged`, which is what triggers the navigation that has to read the mode.
+      onHistoryModeChanged(historyMode)
+
+      const frameHref = iframeRef.current?.contentWindow?.location.href
+      if (frameHref != null) {
+        // Keep the source in sync with where the frame actually is. Without this the effect at the
+        // bottom of this component would see a stale source after a client-side navigation and
+        // force-load the frame, throwing away the page the reader just navigated to.
+        sourceRef.current = normalizeIFrameSrc(frameHref)
+      }
+
+      // A new page starts at the top, just like a document load does. A hash change does not:
+      // jumping to the top is precisely the opposite of what the reader asked for.
+      if (frameLocation.page !== reportedPageRef.current) {
+        reportedPageRef.current = frameLocation.page
+        setScrollY(0)
+      }
+
+      onPageChanged(frameLocation.page)
+      onHashChanged(frameLocation.hash)
+      onSearchChanged(frameLocation.search)
+      reportedTitleRef.current = frameLocation.title ?? ''
+      onTitleChanged(reportedTitleRef.current)
+    }
+
     const iframeLocation = parseIFrameHref(iframeRef)
     if (iframeLocation == null) {
       console.warn('IFrame onload event triggered, but url is null')
@@ -86,6 +130,17 @@ export default function IFrame({
     const frameWindow = iframeRef.current.contentWindow
     if (frameWindow != null) {
       hookFramedDocument(frameWindow, {
+        onNavigated: report,
+
+        onTitleChanged: (title: string): void => {
+          if (title !== reportedTitleRef.current) {
+            reportedTitleRef.current = title
+            onTitleChanged(title)
+          }
+        },
+
+        isAlreadyRecorded: (href: string): boolean => normalizeIFrameSrc(href) === sourceRef.current,
+
         displayHref: (href: string): string => toReadableHref(href),
 
         /**
@@ -114,7 +169,7 @@ export default function IFrame({
          */
         followInTheFrame: (href: string): void => {
           const frameHref = toFrameHref(href)
-          sourceRef.current = frameHref
+          sourceRef.current = normalizeIFrameSrc(frameHref)
           frameWindow.location.replace(frameHref)
         },
 
@@ -129,10 +184,9 @@ export default function IFrame({
       })
     }
 
-    onPageChanged(iframeLocation.page)
-    onHashChanged(iframeLocation.hash)
-    onSearchChanged(iframeLocation.search)
-    onTitleChanged(iframeLocation.title ?? '')
+    // A document load means the frame got here through `location.replace`, which adds no session
+    // history entry of its own: this navigation is vdoc's to record.
+    report('push')
   }
 
   const hashChangeEventListener = useCallback((): void => {
@@ -193,11 +247,17 @@ export default function IFrame({
     if (isNavigationPending) {
       return
     }
-    const srcWithOrigin = `${window.location.origin}${src}`
-    if (sourceRef.current !== srcWithOrigin) {
-      iframeRef.current?.contentWindow?.location.replace(srcWithOrigin)
-      sourceRef.current = srcWithOrigin
+    // Compared through `normalizeIFrameSrc`, the same way `report()` records where the frame is:
+    // if the two composed the address differently, every client-side navigation would look like a
+    // stale source here and be force-loaded away.
+    const normalizedSrc = normalizeIFrameSrc(src)
+    if (sourceRef.current === normalizedSrc) {
+      return
     }
+    sourceRef.current = normalizedSrc
+    // Requested with the address exactly as vdoc's router holds it, not with the normalized one:
+    // what may be ignored when comparing two addresses must still be requested faithfully.
+    iframeRef.current?.contentWindow?.location.replace(`${window.location.origin}${src}`)
   }, [src, isNavigationPending])
 
   return (

--- a/src/ui/components/IFrame.tsx
+++ b/src/ui/components/IFrame.tsx
@@ -6,6 +6,7 @@
 import { useColorScheme } from '@mui/material'
 import { useRouterState } from '@tanstack/react-router'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useContentInset } from '../contexts/ContentInsetContext'
 import { useIFrameScroll } from '../contexts/IFrameScrollContext'
 import { hookFramedDocument } from '../helpers/FramedDocument'
 import {
@@ -16,6 +17,7 @@ import {
 } from '../helpers/IFrame'
 import {
   composeIFrameSrc,
+  type FrameParams,
   normalizeIFrameSrc,
   sanitizeDocuUri,
   toFrameHref,
@@ -45,6 +47,7 @@ export default function IFrame({
 }: Props) {
   const { colorScheme, mode, systemMode } = useColorScheme()
   const { scrollY, setScrollY } = useIFrameScroll()
+  const { contentInset } = useContentInset()
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const sourceRef = useRef<string | undefined>(null)
   const [contentWindow, setContentWindow] = useState<Window | null>()
@@ -59,8 +62,9 @@ export default function IFrame({
   // The handlers installed on the framed window outlive the render that installed them - they stay
   // attached for the lifetime of the framed document - so they read these through refs rather than
   // closing over a value that goes stale on the next render.
-  const colorModeRef = useRef(effectiveColorMode)
-  colorModeRef.current = effectiveColorMode
+  const frameParams: FrameParams = { mode: effectiveColorMode, inset: contentInset }
+  const frameParamsRef = useRef(frameParams)
+  frameParamsRef.current = frameParams
   const scrollYRef = useRef(scrollY)
   scrollYRef.current = scrollY
 
@@ -108,7 +112,7 @@ export default function IFrame({
 
     reloadedForModeRef.current = requestedMode
     restoreScrollYRef.current = scrollYRef.current
-    const target = composeIFrameSrc(frameWindow.location.href, requestedMode)
+    const target = composeIFrameSrc(frameWindow.location.href, { ...frameParamsRef.current, mode: requestedMode })
     sourceRef.current = normalizeIFrameSrc(target)
     frameWindow.location.replace(target)
     return true
@@ -130,7 +134,7 @@ export default function IFrame({
 
     // Apply dark mode. A participating frame may need a reload to do so, in which case the document
     // below is already on its way out and there is nothing worth reporting about it.
-    if (applyColorMode(colorModeRef.current)) {
+    if (applyColorMode(frameParamsRef.current.mode)) {
       return
     }
 
@@ -251,7 +255,7 @@ export default function IFrame({
         followInTheFrame: (href: string): void => {
           const frameHref = toFrameHref(href)
           sourceRef.current = normalizeIFrameSrc(frameHref)
-          frameWindow.location.replace(composeIFrameSrc(frameHref, colorModeRef.current))
+          frameWindow.location.replace(composeIFrameSrc(frameHref, frameParamsRef.current))
         },
 
         /**
@@ -341,7 +345,7 @@ export default function IFrame({
     // color mode is deliberately not a dependency of this effect - switching it must not reload
     // frames that apply it in place. `applyColorMode` reloads the ones that need it.
     iframeRef.current?.contentWindow?.location.replace(
-      composeIFrameSrc(`${window.location.origin}${src}`, colorModeRef.current)
+      composeIFrameSrc(`${window.location.origin}${src}`, frameParamsRef.current)
     )
   }, [src, isNavigationPending])
 

--- a/src/ui/components/IFrame.tsx
+++ b/src/ui/components/IFrame.tsx
@@ -8,8 +8,19 @@ import { useRouterState } from '@tanstack/react-router'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useIFrameScroll } from '../contexts/IFrameScrollContext'
 import { hookFramedDocument } from '../helpers/FramedDocument'
-import { type IFrameHistoryMode, parseIFrameHref, toggleDocumentationColorScheme } from '../helpers/IFrame'
-import { normalizeIFrameSrc, sanitizeDocuUri, toFrameHref, toReadableHref } from '../helpers/RouteHelpers'
+import {
+  type IFrameHistoryMode,
+  parseIFrameHref,
+  toggleDocumentationColorScheme,
+  VDOC_THEME_ATTRIBUTE,
+} from '../helpers/IFrame'
+import {
+  composeIFrameSrc,
+  normalizeIFrameSrc,
+  sanitizeDocuUri,
+  toFrameHref,
+  toReadableHref,
+} from '../helpers/RouteHelpers'
 import type { EffectiveColorMode } from '../interfacesAndTypes/ColorModes'
 import { testIDs } from '../interfacesAndTypes/testIDs'
 
@@ -32,27 +43,81 @@ export default function IFrame({
   onNotFound,
   onHistoryModeChanged,
 }: Props) {
-  const { colorScheme } = useColorScheme()
-  const { setScrollY } = useIFrameScroll()
+  const { colorScheme, mode, systemMode } = useColorScheme()
+  const { scrollY, setScrollY } = useIFrameScroll()
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const sourceRef = useRef<string | undefined>(null)
   const [contentWindow, setContentWindow] = useState<Window | null>()
 
   const currentProjectName = useMemo(() => sanitizeDocuUri(src).projectName, [src])
 
+  // MUI resolves `colorScheme` for us, but it is undefined until the color scheme has been
+  // initialized, so fall back to the raw setting and resolve `system` here.
+  const resolvedColorScheme = colorScheme ?? (mode === 'system' ? systemMode : mode)
+  const effectiveColorMode: EffectiveColorMode = resolvedColorScheme === 'dark' ? 'dark' : 'light'
+
+  // The handlers installed on the framed window outlive the render that installed them - they stay
+  // attached for the lifetime of the framed document - so they read these through refs rather than
+  // closing over a value that goes stale on the next render.
+  const colorModeRef = useRef(effectiveColorMode)
+  colorModeRef.current = effectiveColorMode
+  const scrollYRef = useRef(scrollY)
+  scrollYRef.current = scrollY
+
   /** Last page reported, so the scroll position is only reset when the page actually changed. */
   const reportedPageRef = useRef<string | null>(null)
   /** Last title reported, so a title arriving late is only forwarded when it is a change. */
   const reportedTitleRef = useRef<string | null>(null)
+  /** Mode the frame was last reloaded for, so a frame that ignores the parameter cannot loop. */
+  const reloadedForModeRef = useRef<EffectiveColorMode | null>(null)
+  /** Scroll position to restore after a reload a color mode change triggered. */
+  const restoreScrollYRef = useRef<number | null>(null)
 
-  const setDarkMode = useCallback((mode: EffectiveColorMode) => {
-    toggleDocumentationColorScheme(iframeRef, mode)
+  /**
+   * Bring the framed documentation to `requestedMode`.
+   *
+   * A frame that declares {@link VDOC_THEME_ATTRIBUTE} applies the mode itself, from the URL, so it
+   * is asked by reloading with the parameter. A frame that does not (sphinx-awesome, doxygen) keeps
+   * the legacy in-place class toggle, which is instant and must never turn into a reload.
+   *
+   * @returns whether a reload was started.
+   */
+  const applyColorMode = useCallback((requestedMode: EffectiveColorMode): boolean => {
+    const frameWindow = iframeRef.current?.contentWindow
+    const documentElement = iframeRef.current?.contentDocument?.documentElement
+    if (!frameWindow || !documentElement) {
+      return false
+    }
+
+    const declaredMode = documentElement.getAttribute(VDOC_THEME_ATTRIBUTE)
+    if (declaredMode === null) {
+      toggleDocumentationColorScheme(iframeRef, requestedMode)
+      return false
+    }
+
+    if (declaredMode === requestedMode) {
+      // The frame already applied what is being asked for, so there is nothing to reload for.
+      reloadedForModeRef.current = requestedMode
+      return false
+    }
+    if (reloadedForModeRef.current === requestedMode) {
+      // Already reloaded for this mode and the frame still declares another one. It sets the
+      // attribute but does not honor the parameter; reloading again would only loop.
+      return false
+    }
+
+    reloadedForModeRef.current = requestedMode
+    restoreScrollYRef.current = scrollYRef.current
+    const target = composeIFrameSrc(frameWindow.location.href, requestedMode)
+    sourceRef.current = normalizeIFrameSrc(target)
+    frameWindow.location.replace(target)
+    return true
   }, [])
 
   // Update documentation's theme
   useEffect(() => {
-    setDarkMode(colorScheme as 'light' | 'dark')
-  }, [colorScheme, setDarkMode])
+    applyColorMode(effectiveColorMode)
+  }, [effectiveColorMode, applyColorMode])
 
   const onIframeLoad = (): void => {
     if (iframeRef.current === null) {
@@ -63,14 +128,28 @@ export default function IFrame({
     // Cache current active content windows for other processes
     setContentWindow(iframeRef.current?.contentWindow)
 
-    // Apply dark mode
-    setDarkMode(colorScheme as 'light' | 'dark')
+    // Apply dark mode. A participating frame may need a reload to do so, in which case the document
+    // below is already on its way out and there is nothing worth reporting about it.
+    if (applyColorMode(colorModeRef.current)) {
+      return
+    }
 
     // Set up scroll listener
     const contentWindow = iframeRef.current.contentWindow
     if (contentWindow) {
-      // Reset scroll position when iframe loads
-      setScrollY(0)
+      // Reset scroll position when iframe loads, unless this load is the reload of the very same
+      // page that a color mode change triggered - then the reader must stay where they were.
+      const restoreScrollY = restoreScrollYRef.current
+      restoreScrollYRef.current = null
+      if (restoreScrollY !== null && restoreScrollY > 0) {
+        contentWindow.scrollTo(0, restoreScrollY)
+        // The framed document may still be laying out, in which case the scroll above is clamped to
+        // a page that has not reached its full height yet. Re-apply once it has settled.
+        contentWindow.requestAnimationFrame(() => contentWindow.scrollTo(0, restoreScrollY))
+        setScrollY(restoreScrollY)
+      } else {
+        setScrollY(0)
+      }
 
       const handleScroll = () => {
         const scrollY = contentWindow.document.documentElement.scrollTop || contentWindow.document.body.scrollTop
@@ -162,15 +241,17 @@ export default function IFrame({
 
         /**
          * The anchor carries the readable address, so this resolves the one that reaches the file
-         * back out of it. `replace` rather than an assignment, so that the framed navigation adds
-         * no session history entry - vdoc's own router adds one for the same navigation, and two
-         * would make the back button need two clicks per page.
+         * back out of it, and requests the color mode along with it - without the parameter the new
+         * document would not declare the attribute, and the frame would drop out of the contract
+         * mid-navigation. `replace` rather than an assignment, so that the framed navigation adds no
+         * session history entry - vdoc's own router adds one for the same navigation, and two would
+         * make the back button need two clicks per page.
          * From here: https://www.ozzu.com/questions/358584/how-do-you-ignore-iframes-javascript-history
          */
         followInTheFrame: (href: string): void => {
           const frameHref = toFrameHref(href)
           sourceRef.current = normalizeIFrameSrc(frameHref)
-          frameWindow.location.replace(frameHref)
+          frameWindow.location.replace(composeIFrameSrc(frameHref, colorModeRef.current))
         },
 
         /**
@@ -256,8 +337,12 @@ export default function IFrame({
     }
     sourceRef.current = normalizedSrc
     // Requested with the address exactly as vdoc's router holds it, not with the normalized one:
-    // what may be ignored when comparing two addresses must still be requested faithfully.
-    iframeRef.current?.contentWindow?.location.replace(`${window.location.origin}${src}`)
+    // what may be ignored when comparing two addresses must still be requested faithfully. The
+    // color mode is deliberately not a dependency of this effect - switching it must not reload
+    // frames that apply it in place. `applyColorMode` reloads the ones that need it.
+    iframeRef.current?.contentWindow?.location.replace(
+      composeIFrameSrc(`${window.location.origin}${src}`, colorModeRef.current)
+    )
   }, [src, isNavigationPending])
 
   return (

--- a/src/ui/components/MenuBar.tsx
+++ b/src/ui/components/MenuBar.tsx
@@ -13,7 +13,8 @@ import {
   useTheme,
 } from '@mui/material'
 import { useNavigate, useParams } from '@tanstack/react-router'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useContentInset } from '../contexts/ContentInsetContext'
 import { fetchAppVersion, fetchPluginConfig, fetchProjectVersion, fetchProjectVersions } from '../helpers/APIFunctions'
 import type OramaPluginT from '../interfacesAndTypes/plugins/OramaPluginT'
 import type ThemePluginT from '../interfacesAndTypes/plugins/ThemePlugin'
@@ -158,6 +159,25 @@ export default function MenuBar({ hide = false }: { hide?: boolean }) {
     fetchAppVersion().then((appVersion) => setAppVersion(appVersion))
   }, [])
 
+  const { setContentInset } = useContentInset()
+  const toolbarRef = useRef<HTMLDivElement>(null)
+
+  // Report where vdoc's own header content starts, so the framed documentation can line its header
+  // up with it. Measured rather than derived from the theme: the gutter is MUI's responsive
+  // `Toolbar` default today, and a second copy of that rule would be a second thing to keep in step.
+  // Observed rather than read once, because the gutter changes with the breakpoint.
+  useEffect(() => {
+    const toolbar = toolbarRef.current
+    if (toolbar === null) {
+      return
+    }
+    const report = () => setContentInset(Number.parseFloat(window.getComputedStyle(toolbar).paddingLeft) || 0)
+    report()
+    const observer = new ResizeObserver(report)
+    observer.observe(toolbar)
+    return () => observer.disconnect()
+  }, [setContentInset])
+
   return (
     <Slide appear={false} direction="down" in={!hide}>
       <AppBar
@@ -168,7 +188,7 @@ export default function MenuBar({ hide = false }: { hide?: boolean }) {
         }}
         elevation={0}
       >
-        <Toolbar>
+        <Toolbar ref={toolbarRef}>
           <Grid
             container
             spacing={1}

--- a/src/ui/components/RootLayout.tsx
+++ b/src/ui/components/RootLayout.tsx
@@ -2,6 +2,7 @@ import { Box, CssBaseline, createTheme, Slide, ThemeProvider, useColorScheme } f
 import InitColorSchemeScript from '@mui/material/InitColorSchemeScript'
 import { Outlet } from '@tanstack/react-router'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { ContentInsetProvider } from '../contexts/ContentInsetProvider'
 import { useIFrameScroll } from '../contexts/IFrameScrollContext'
 import { IFrameScrollProvider } from '../contexts/IFrameScrollProvider'
 import MenuBar from './MenuBar'
@@ -131,7 +132,9 @@ export function RootComponent() {
       <CssBaseline />
       <InitColorSchemeScript />
       <IFrameScrollProvider>
-        <ThemedComponent />
+        <ContentInsetProvider>
+          <ThemedComponent />
+        </ContentInsetProvider>
       </IFrameScrollProvider>
     </ThemeProvider>
   )

--- a/src/ui/contexts/ContentInsetContext.tsx
+++ b/src/ui/contexts/ContentInsetContext.tsx
@@ -1,0 +1,22 @@
+import { createContext, useContext } from 'react'
+
+export interface ContentInsetContextType {
+  /**
+   * Horizontal offset vdoc insets its own header content by, in CSS pixels.
+   *
+   * Measured rather than written down: the framed documentation aligns its own header content to it,
+   * and a constant would have to be kept in step with vdoc's layout by hand, in another repository.
+   * `0` means not measured yet, in which case nothing is sent and the frame keeps its own layout.
+   */
+  contentInset: number
+  setContentInset: (contentInset: number) => void
+}
+
+export const ContentInsetContext = createContext<ContentInsetContextType>({
+  contentInset: 0,
+  setContentInset: () => {},
+})
+
+export function useContentInset() {
+  return useContext(ContentInsetContext)
+}

--- a/src/ui/contexts/ContentInsetProvider.tsx
+++ b/src/ui/contexts/ContentInsetProvider.tsx
@@ -1,0 +1,11 @@
+import { type ReactNode, useState } from 'react'
+
+import { ContentInsetContext } from './ContentInsetContext'
+
+export function ContentInsetProvider({ children }: { children: ReactNode }) {
+  const [contentInset, setContentInset] = useState(0)
+
+  return (
+    <ContentInsetContext.Provider value={{ contentInset, setContentInset }}>{children}</ContentInsetContext.Provider>
+  )
+}

--- a/src/ui/helpers/FramedDocument.ts
+++ b/src/ui/helpers/FramedDocument.ts
@@ -1,18 +1,29 @@
+import type { IFrameHistoryMode } from './IFrame'
+
 /**
  * Marker set on a framed window once it is hooked. `load` can fire more than once for the same
- * document; hooking it twice would install a second set of listeners and handle every click
- * twice, the second time on a frame that is already navigating away.
+ * document; hooking it twice would stack a second `history.pushState` wrapper, report every
+ * navigation N times and handle every click twice.
  */
 type HookedWindow = Window & typeof globalThis & { __vdocFrameHooked?: boolean }
 
 /**
- * What vdoc wants done with the links in a framed document.
+ * What vdoc wants to know about a framed document, and what it wants done with the links in it.
  *
  * Everything here is a decision only vdoc can make: which project a link belongs to, where vdoc's
- * own interface should send the reader, which address it wants a link to show. The mechanics of
- * noticing a click and of reaching the anchors belong to {@link hookFramedDocument}.
+ * own interface should send the reader, what its address bar should say. The mechanics of noticing
+ * any of it belong to {@link hookFramedDocument}.
  */
 export interface FramedDocumentHandlers {
+  /** The frame navigated itself, without discarding the document. */
+  onNavigated: (historyMode: IFrameHistoryMode) => void
+  /** The framed document changed its title, which a client-side router does after navigating. */
+  onTitleChanged: (title: string) => void
+  /**
+   * Whether `href` is where vdoc already believes the frame is. Only vdoc knows when two addresses
+   * are the same page, so it answers rather than being asked for a string.
+   */
+  isAlreadyRecorded: (href: string) => boolean
   /** The address a link should carry for hovering, copying and the browser's new-tab shortcuts. */
   displayHref: (href: string) => string
   /** Whether a link leads somewhere that must not take over the frame. */
@@ -46,8 +57,8 @@ function isDownload(anchor: HTMLAnchorElement): boolean {
 }
 
 /**
- * Subscribe to a framed document, so that vdoc stays in charge of the links that lead out of it
- * and the links show the address vdoc's own interface answers for.
+ * Subscribe to a framed document, so that vdoc learns where it goes, stays in charge of the links
+ * that lead out of it, and the links show the address vdoc's own interface answers for.
  *
  * Called once per framed document; further calls for the same document do nothing.
  *
@@ -60,6 +71,37 @@ export function hookFramedDocument(frameWindow: Window, handlers: FramedDocument
     return
   }
   hookedWindow.__vdocFrameHooked = true
+
+  // Single page documentation swaps pages in place with history.pushState. No document is
+  // discarded, so no `load` fires, and neither method emits an event of its own - wrapping them is
+  // the only way to learn about those navigations.
+  for (const method of ['pushState', 'replaceState'] as const) {
+    const original = frameWindow.history[method].bind(frameWindow.history)
+    frameWindow.history[method] = (...args: Parameters<History['pushState']>) => {
+      original(...args)
+      // The frame has already written its own history entry (or deliberately replaced it), so vdoc
+      // must only correct that entry's address instead of adding a second one.
+      handlers.onNavigated('replace')
+    }
+  }
+
+  frameWindow.addEventListener('popstate', () => {
+    // popstate also fires for the fragment navigations vdoc performs itself, and when a top-level
+    // traversal restores a frame position vdoc already recorded. Only a move the frame made on its
+    // own is news here - reporting the others would overwrite the address vdoc is in the middle of
+    // navigating to.
+    if (handlers.isAlreadyRecorded(frameWindow.location.href)) {
+      return
+    }
+    handlers.onNavigated('replace')
+  })
+
+  // A client-side router sets the title after the navigation, so the title read while handling the
+  // navigation itself is still the previous page's. Watch the head for the one that arrives late.
+  new hookedWindow.MutationObserver(() => handlers.onTitleChanged(frameWindow.document.title)).observe(
+    frameWindow.document.head,
+    { childList: true, subtree: true, characterData: true }
+  )
 
   // Show the readable address rather than the one that reaches the file, so that hovering, the
   // status bar, copying a link and the browser's own new-tab shortcuts all name the page the way

--- a/src/ui/helpers/IFrame.ts
+++ b/src/ui/helpers/IFrame.ts
@@ -1,6 +1,6 @@
 import type { RefObject } from 'react'
 import type { EffectiveColorMode } from '../interfacesAndTypes/ColorModes'
-import { FRAME_PATH_PREFIX, VDOC_THEME_PARAM } from './RouteHelpers'
+import { FRAME_PATH_PREFIX, VDOC_FRAME_PARAMS, VDOC_THEME_PARAM } from './RouteHelpers'
 
 export interface IFrameLocation {
   name: string
@@ -79,10 +79,12 @@ export function parseIFrameHref(iframeRef: RefObject<HTMLIFrameElement | null>):
     const page = pageParts.join('/')
 
     // Extract search as URLSearchParams object and hash without the '#' prefix.
-    // `vdoc-theme` is vdoc's own request to the frame, not part of the page's address: it must not
-    // reach vdoc's address bar, or it would be appended a second time on the next compose.
+    // vdoc's own parameters are requests to the frame, not part of the page's address: they must not
+    // reach vdoc's address bar, or they would be appended a second time on the next compose.
     const search = new URLSearchParams(url.search)
-    search.delete(VDOC_THEME_PARAM)
+    for (const param of VDOC_FRAME_PARAMS) {
+      search.delete(param)
+    }
     const hash = url.hash.startsWith('#') ? url.hash.slice(1) : url.hash
 
     return {

--- a/src/ui/helpers/IFrame.ts
+++ b/src/ui/helpers/IFrame.ts
@@ -1,6 +1,6 @@
 import type { RefObject } from 'react'
 import type { EffectiveColorMode } from '../interfacesAndTypes/ColorModes'
-import { FRAME_PATH_PREFIX } from './RouteHelpers'
+import { FRAME_PATH_PREFIX, VDOC_THEME_PARAM } from './RouteHelpers'
 
 export interface IFrameLocation {
   name: string
@@ -19,6 +19,15 @@ export interface IFrameLocation {
  * the entry itself, so vdoc must only correct the address of that entry).
  */
 export type IFrameHistoryMode = 'push' | 'replace'
+/**
+ * Attribute a framed document sets on its `<html>` element to declare that it read
+ * {@link VDOC_THEME_PARAM} and applied the requested mode itself. Its value is the mode it applied.
+ *
+ * Frames that do not set it are driven through {@link toggleDocumentationColorScheme} instead.
+ * See `docs/frame_contract.md`.
+ */
+export const VDOC_THEME_ATTRIBUTE = 'data-vdoc-theme'
+
 export function toggleDocumentationColorScheme(
   iframeRef: React.RefObject<HTMLIFrameElement | null>,
   mode: EffectiveColorMode
@@ -69,8 +78,11 @@ export function parseIFrameHref(iframeRef: RefObject<HTMLIFrameElement | null>):
     const [name, version, ...pageParts] = pathParts
     const page = pageParts.join('/')
 
-    // Extract search as URLSearchParams object and hash without the '#' prefix
+    // Extract search as URLSearchParams object and hash without the '#' prefix.
+    // `vdoc-theme` is vdoc's own request to the frame, not part of the page's address: it must not
+    // reach vdoc's address bar, or it would be appended a second time on the next compose.
     const search = new URLSearchParams(url.search)
+    search.delete(VDOC_THEME_PARAM)
     const hash = url.hash.startsWith('#') ? url.hash.slice(1) : url.hash
 
     return {

--- a/src/ui/helpers/IFrame.ts
+++ b/src/ui/helpers/IFrame.ts
@@ -11,6 +11,14 @@ export interface IFrameLocation {
   title: string
 }
 
+/**
+ * How vdoc's own router should record a page change reported by the frame.
+ *
+ * `push` for document loads (the frame navigated with `location.replace` and added no session
+ * history entry, so vdoc adds one), `replace` for client-side navigation (the frame already added
+ * the entry itself, so vdoc must only correct the address of that entry).
+ */
+export type IFrameHistoryMode = 'push' | 'replace'
 export function toggleDocumentationColorScheme(
   iframeRef: React.RefObject<HTMLIFrameElement | null>,
   mode: EffectiveColorMode

--- a/src/ui/helpers/RouteHelpers.ts
+++ b/src/ui/helpers/RouteHelpers.ts
@@ -1,3 +1,5 @@
+import type { EffectiveColorMode } from '../interfacesAndTypes/ColorModes'
+
 /**
  * Path prefix under which vdoc serves the published documentation files themselves.
  *
@@ -6,6 +8,14 @@
  * application into the frame instead of the next documentation page.
  */
 export const FRAME_PATH_PREFIX = '/static/projects/'
+
+/**
+ * Query parameter vdoc appends to the frame URL to request a color mode.
+ *
+ * See `docs/frame_contract.md`. It is vdoc's request to the frame, never part of a page's address,
+ * which is why {@link normalizeIFrameSrc} and `parseIFrameHref` both drop it again.
+ */
+export const VDOC_THEME_PARAM = 'vdoc-theme'
 
 /**
  * `pathname` with the frame path prefix removed, if it carries one.
@@ -28,6 +38,11 @@ export function stripFramePrefix(pathname: string): string {
  * Foreign addresses are returned verbatim, addresses of vdoc's own origin absolute, and applying
  * this to an address that is already readable changes nothing.
  *
+ * {@link VDOC_THEME_PARAM} is dropped, because the readable form is an address in vdoc's own
+ * namespace and vdoc's request to the frame has no meaning there. It has to be dropped explicitly:
+ * a fragment-only link resolves against the whole address of the document it sits in, so every
+ * `<a href="#section">` in a framed page would otherwise display and copy vdoc's parameter.
+ *
  * @param href The address to convert, absolute or relative to `origin`.
  * @param origin The origin vdoc is served from.
  */
@@ -36,6 +51,7 @@ export function toReadableHref(href: string, origin: string = window.location.or
   if (url.origin !== origin) {
     return href
   }
+  url.searchParams.delete(VDOC_THEME_PARAM)
   url.pathname = stripFramePrefix(url.pathname)
   return url.href
 }
@@ -71,15 +87,36 @@ export function toFrameHref(href: string, origin: string = window.location.origi
  * the frame and undo that very navigation. Composing the two sides differently is the mistake this
  * function exists to prevent.
  *
- * A trailing slash is deliberately not a difference here. A generator that publishes a page as a
- * directory is reached through a redirect that adds one, while vdoc's router normalizes it away
- * again; treating the two forms as different pages reloads the frame for as long as it is open.
+ * Two differences are deliberately not differences here:
+ *
+ * - {@link VDOC_THEME_PARAM}, which belongs to the URL that gets loaded but never to the
+ *   comparison, or changing the color mode would reload every frame - including the ones that
+ *   apply it in place, instantly and without a reload.
+ * - A trailing slash. A generator that publishes a page as a directory is reached through a
+ *   redirect that adds one, while vdoc's router normalizes it away again; treating the two forms
+ *   as different pages reloads the frame for as long as it is open.
  */
 export function normalizeIFrameSrc(src: string, origin: string = window.location.origin): string {
   const url = new URL(src, origin)
+  url.searchParams.delete(VDOC_THEME_PARAM)
   if (url.pathname.length > 1 && url.pathname.endsWith('/')) {
     url.pathname = url.pathname.slice(0, -1)
   }
+  return url.href
+}
+
+/**
+ * The URL to load the frame with: `src` carrying the requested color mode as
+ * {@link VDOC_THEME_PARAM}.
+ *
+ * Composed through `URLSearchParams` rather than by string concatenation, because `src` may
+ * already carry a query string or a hash. The path is left exactly as given, unlike in
+ * {@link normalizeIFrameSrc} - what may be ignored when comparing two addresses must still be
+ * requested faithfully.
+ */
+export function composeIFrameSrc(src: string, mode: EffectiveColorMode, origin?: string): string {
+  const url = new URL(src, origin ?? window.location.origin)
+  url.searchParams.set(VDOC_THEME_PARAM, mode)
   return url.href
 }
 

--- a/src/ui/helpers/RouteHelpers.ts
+++ b/src/ui/helpers/RouteHelpers.ts
@@ -62,6 +62,27 @@ export function toFrameHref(href: string, origin: string = window.location.origi
   return url.href
 }
 
+/**
+ * The identity of an iframe URL: what makes two addresses the same page for vdoc's purposes.
+ *
+ * This is the single string used to answer "is the frame already showing this?". Both the address
+ * vdoc wants and the one the frame reports after navigating itself are reduced with this function,
+ * so that a client-side navigation cannot be mistaken for a stale source - which would force-load
+ * the frame and undo that very navigation. Composing the two sides differently is the mistake this
+ * function exists to prevent.
+ *
+ * A trailing slash is deliberately not a difference here. A generator that publishes a page as a
+ * directory is reached through a redirect that adds one, while vdoc's router normalizes it away
+ * again; treating the two forms as different pages reloads the frame for as long as it is open.
+ */
+export function normalizeIFrameSrc(src: string, origin: string = window.location.origin): string {
+  const url = new URL(src, origin)
+  if (url.pathname.length > 1 && url.pathname.endsWith('/')) {
+    url.pathname = url.pathname.slice(0, -1)
+  }
+  return url.href
+}
+
 export interface SanitizeDocUriResI {
   projectName: string
   version: string

--- a/src/ui/helpers/RouteHelpers.ts
+++ b/src/ui/helpers/RouteHelpers.ts
@@ -9,13 +9,43 @@ import type { EffectiveColorMode } from '../interfacesAndTypes/ColorModes'
  */
 export const FRAME_PATH_PREFIX = '/static/projects/'
 
-/**
- * Query parameter vdoc appends to the frame URL to request a color mode.
- *
- * See `docs/frame_contract.md`. It is vdoc's request to the frame, never part of a page's address,
- * which is why {@link normalizeIFrameSrc} and `parseIFrameHref` both drop it again.
- */
+/** Query parameter vdoc appends to the frame URL to request a color mode. */
 export const VDOC_THEME_PARAM = 'vdoc-theme'
+
+/**
+ * Query parameter vdoc appends to tell the frame where its own content starts horizontally.
+ *
+ * Sent as a parameter rather than written down as a constant because vdoc keeps every published
+ * version forever: a number baked into a site's stylesheet at build time would strand every site
+ * published before vdoc next changed its own gutter.
+ */
+export const VDOC_INSET_PARAM = 'vdoc-inset'
+
+/**
+ * Every parameter vdoc adds to the frame URL for the frame's own benefit.
+ *
+ * These are vdoc's requests to the frame, never part of a page's address, so all three places that
+ * turn a frame URL back into an address vdoc can show or compare drop the whole set:
+ * {@link toReadableHref}, {@link normalizeIFrameSrc} and `parseIFrameHref`. Adding a parameter here
+ * is what keeps that from having to be remembered three times - forgetting one of them once already
+ * put `?vdoc-theme=…` into the href of every fragment link in a framed page.
+ */
+export const VDOC_FRAME_PARAMS: readonly string[] = [VDOC_THEME_PARAM, VDOC_INSET_PARAM]
+
+/** Removes every parameter of vdoc's own from `url`, in place. */
+function deleteFrameParams(url: URL): void {
+  for (const param of VDOC_FRAME_PARAMS) {
+    url.searchParams.delete(param)
+  }
+}
+
+/** What vdoc tells the frame about itself, on the URL it loads it with. */
+export interface FrameParams {
+  /** The color mode the frame should apply, always resolved - never `system`. */
+  mode: EffectiveColorMode
+  /** Horizontal offset vdoc insets its own content by, in CSS pixels. Omitted if not measured. */
+  inset?: number
+}
 
 /**
  * `pathname` with the frame path prefix removed, if it carries one.
@@ -38,10 +68,10 @@ export function stripFramePrefix(pathname: string): string {
  * Foreign addresses are returned verbatim, addresses of vdoc's own origin absolute, and applying
  * this to an address that is already readable changes nothing.
  *
- * {@link VDOC_THEME_PARAM} is dropped, because the readable form is an address in vdoc's own
- * namespace and vdoc's request to the frame has no meaning there. It has to be dropped explicitly:
- * a fragment-only link resolves against the whole address of the document it sits in, so every
- * `<a href="#section">` in a framed page would otherwise display and copy vdoc's parameter.
+ * {@link VDOC_FRAME_PARAMS} are dropped, because the readable form is an address in vdoc's own
+ * namespace and vdoc's requests to the frame have no meaning there. They have to be dropped
+ * explicitly: a fragment-only link resolves against the whole address of the document it sits in, so
+ * every `<a href="#section">` in a framed page would otherwise display and copy them.
  *
  * @param href The address to convert, absolute or relative to `origin`.
  * @param origin The origin vdoc is served from.
@@ -51,7 +81,7 @@ export function toReadableHref(href: string, origin: string = window.location.or
   if (url.origin !== origin) {
     return href
   }
-  url.searchParams.delete(VDOC_THEME_PARAM)
+  deleteFrameParams(url)
   url.pathname = stripFramePrefix(url.pathname)
   return url.href
 }
@@ -89,16 +119,17 @@ export function toFrameHref(href: string, origin: string = window.location.origi
  *
  * Two differences are deliberately not differences here:
  *
- * - {@link VDOC_THEME_PARAM}, which belongs to the URL that gets loaded but never to the
- *   comparison, or changing the color mode would reload every frame - including the ones that
- *   apply it in place, instantly and without a reload.
+ * - {@link VDOC_FRAME_PARAMS}, which belong to the URL that gets loaded but never to the comparison.
+ *   Otherwise changing the color mode would reload every frame - including the ones that apply it in
+ *   place, instantly and without a reload - and every window resize that moves vdoc's own gutter
+ *   would reload the frame as well.
  * - A trailing slash. A generator that publishes a page as a directory is reached through a
  *   redirect that adds one, while vdoc's router normalizes it away again; treating the two forms
  *   as different pages reloads the frame for as long as it is open.
  */
 export function normalizeIFrameSrc(src: string, origin: string = window.location.origin): string {
   const url = new URL(src, origin)
-  url.searchParams.delete(VDOC_THEME_PARAM)
+  deleteFrameParams(url)
   if (url.pathname.length > 1 && url.pathname.endsWith('/')) {
     url.pathname = url.pathname.slice(0, -1)
   }
@@ -106,17 +137,24 @@ export function normalizeIFrameSrc(src: string, origin: string = window.location
 }
 
 /**
- * The URL to load the frame with: `src` carrying the requested color mode as
- * {@link VDOC_THEME_PARAM}.
+ * The URL to load the frame with: `src` carrying what vdoc tells the frame about itself.
  *
- * Composed through `URLSearchParams` rather than by string concatenation, because `src` may
- * already carry a query string or a hash. The path is left exactly as given, unlike in
+ * Composed through `URLSearchParams` rather than by string concatenation, because `src` may already
+ * carry a query string or a hash. The path is left exactly as given, unlike in
  * {@link normalizeIFrameSrc} - what may be ignored when comparing two addresses must still be
  * requested faithfully.
+ *
+ * The inset is omitted while it is unknown, which the contract allows: a frame without it is
+ * misaligned by vdoc's gutter, not broken.
  */
-export function composeIFrameSrc(src: string, mode: EffectiveColorMode, origin?: string): string {
+export function composeIFrameSrc(src: string, params: FrameParams, origin?: string): string {
   const url = new URL(src, origin ?? window.location.origin)
-  url.searchParams.set(VDOC_THEME_PARAM, mode)
+  url.searchParams.set(VDOC_THEME_PARAM, params.mode)
+  if (params.inset != null && params.inset > 0) {
+    url.searchParams.set(VDOC_INSET_PARAM, String(Math.round(params.inset)))
+  } else {
+    url.searchParams.delete(VDOC_INSET_PARAM)
+  }
   return url.href
 }
 

--- a/src/ui/routes/$projectName/$version.$.tsx
+++ b/src/ui/routes/$projectName/$version.$.tsx
@@ -1,55 +1,20 @@
-import SearchOffIcon from '@mui/icons-material/SearchOff'
-import { createFileRoute, redirect, useRouter } from '@tanstack/react-router'
-import { useCallback } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
 import { object, optional, string } from 'valibot'
 import { DocumentationComponent } from '../../components/DocumentationComponent'
-import ErrorComponent from '../../components/ErrorComponent'
-import { LoadingSpinner } from '../../components/LoadingSpinner'
-import { fetchProjectVersion } from '../../helpers/APIFunctions'
-import type { FastAPIAxiosErrorT } from '../../interfacesAndTypes/Error'
 
 // Schema for search parameters
 const searchSchema = object({
   q: optional(string()),
 })
 
-const fetchVersionAndLatestVersion = async (projectName: string, version: string): Promise<string> => {
-  // Check if requested version is available. If not, the loader throws an error and the error component is shown
-  await fetchProjectVersion(projectName, version)
-
-  return await fetchProjectVersion(projectName, 'latest')
-}
-
+/**
+ * A single documentation page.
+ *
+ * Deliberately without a loader: this route's params carry the page, and every page change - which
+ * for single page documentation happens without a document load - would otherwise re-run it. What
+ * has to be resolved for the whole project version is resolved by the route above.
+ */
 export const Route = createFileRoute('/$projectName/$version/$')({
   component: DocumentationComponent,
   validateSearch: searchSchema,
-  loader: async ({ params: { projectName, version, _splat } }) => {
-    const latestVersion = await fetchVersionAndLatestVersion(projectName, version)
-    if (version === 'latest') {
-      throw redirect({
-        to: '/$projectName/$version/$',
-        params: {
-          projectName,
-          version: latestVersion,
-          _splat: _splat || '',
-        },
-        hash: true, // Preserve the hash from the original URL
-        search: true, // Preserve the search params from the original URL
-      })
-    }
-    return [version, latestVersion]
-  },
-  pendingComponent: LoadingSpinner,
-  errorComponent: ({ error }) => {
-    const ErrorComponentWithRouter = () => {
-      const router = useRouter()
-      const handleGoBack = useCallback(() => {
-        router.history.back()
-      }, [router])
-
-      return <ErrorComponent iconClass={SearchOffIcon} error={error as FastAPIAxiosErrorT} onAction={handleGoBack} />
-    }
-
-    return <ErrorComponentWithRouter />
-  },
 })

--- a/src/ui/routes/$projectName/$version.tsx
+++ b/src/ui/routes/$projectName/$version.tsx
@@ -1,0 +1,59 @@
+import SearchOffIcon from '@mui/icons-material/SearchOff'
+import { createFileRoute, Outlet, redirect, useRouter } from '@tanstack/react-router'
+import { useCallback } from 'react'
+import ErrorComponent from '../../components/ErrorComponent'
+import { LoadingSpinner } from '../../components/LoadingSpinner'
+import { fetchProjectVersion } from '../../helpers/APIFunctions'
+import { sanitizeDocuUri } from '../../helpers/RouteHelpers'
+import type { FastAPIAxiosErrorT } from '../../interfacesAndTypes/Error'
+
+const fetchVersionAndLatestVersion = async (projectName: string, version: string): Promise<string> => {
+  // Check if requested version is available. If not, the loader throws an error and the error component is shown
+  await fetchProjectVersion(projectName, version)
+
+  return await fetchProjectVersion(projectName, 'latest')
+}
+
+/**
+ * Resolves which version of a project is being read, for every page of it.
+ *
+ * This sits on `/$projectName/$version` rather than on the `/$/` route below it, because that is
+ * what it depends on. A route's loader re-runs whenever its own params change, so while this lived
+ * on the page route, turning a page inside the frame - which changes nothing but the splat - fired
+ * two sequential, uncached HTTP requests for an answer that cannot have changed. Single page
+ * documentation turns pages without a document load, so that happened on every click.
+ */
+export const Route = createFileRoute('/$projectName/$version')({
+  component: Outlet,
+  loader: async ({ params: { projectName, version }, location }) => {
+    const latestVersion = await fetchVersionAndLatestVersion(projectName, version)
+    if (version === 'latest') {
+      throw redirect({
+        to: '/$projectName/$version/$',
+        params: {
+          projectName,
+          version: latestVersion,
+          // The page to land on is not in this route's params, so it is read back out of the
+          // address being resolved.
+          _splat: sanitizeDocuUri(location.pathname)._splat,
+        },
+        hash: true, // Preserve the hash from the original URL
+        search: true, // Preserve the search params from the original URL
+      })
+    }
+    return [version, latestVersion]
+  },
+  pendingComponent: LoadingSpinner,
+  errorComponent: ({ error }) => {
+    const ErrorComponentWithRouter = () => {
+      const router = useRouter()
+      const handleGoBack = useCallback(() => {
+        router.history.back()
+      }, [router])
+
+      return <ErrorComponent iconClass={SearchOffIcon} error={error as FastAPIAxiosErrorT} onAction={handleGoBack} />
+    }
+
+    return <ErrorComponentWithRouter />
+  },
+})

--- a/tests/ui/resources/mockedSinglePageApp.html
+++ b/tests/ui/resources/mockedSinglePageApp.html
@@ -1,0 +1,131 @@
+<html lang="en">
+  <head>
+    <!--
+      Minimal stand-in for a single-page documentation generator (Docusaurus and friends): pages
+      are swapped in place with history.pushState, no document is discarded, and no `load` fires.
+    -->
+    <style>
+      body {
+        background-color: rgb(227, 242, 253);
+        color: black;
+        margin: 0;
+        font-family: sans-serif;
+      }
+      .page {
+        padding: 16px;
+      }
+      .filler {
+        height: 1200px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script>
+      ;(() => {
+        const basePath = window.location.pathname.replace(/^(.*\/static\/projects\/[^/]+\/[^/]+\/).*$/, '$1')
+
+        // Links this application routes itself carry their target in `data-route`, the way a
+        // component based router carries it in a prop. The router never reads the DOM href, which
+        // is what leaves vdoc free to show the readable address there.
+        const pages = {
+          'index.html': {
+            title: 'SPA Index',
+            body: `
+              <h1>Single page application index</h1>
+              <ul>
+                <li><a href="${basePath}guide.html" data-route="guide.html">Go to the guide</a></li>
+                <li><a href="${basePath}api.html" data-route="api.html">Go to the API</a></li>
+                <li>
+                  <a href="${basePath}index.html?tab=examples" data-route="index.html?tab=examples">
+                    Go to the index with a search parameter
+                  </a>
+                </li>
+                <li><a href="/static/projects/example-project-02/1.0.0/index.html">Go to another project</a></li>
+                <li><a href="https://example.com/" target="_blank">Go to an external site</a></li>
+              </ul>
+              <div class="filler"></div>
+              <h2 id="section1">Section 1</h2>
+              <div class="filler"></div>
+            `,
+          },
+          'guide.html': {
+            title: 'SPA Guide',
+            body: `
+              <h1>Guide</h1>
+              <ul>
+                <li><a href="${basePath}index.html" data-route="index.html">Back to the index</a></li>
+                <li><a href="${basePath}api.html" data-route="api.html">Go to the API</a></li>
+                <li><a href="#chapter2">Jump to chapter 2</a></li>
+              </ul>
+              <div class="filler"></div>
+              <h2 id="chapter2">Chapter 2</h2>
+              <div class="filler"></div>
+            `,
+          },
+          'api.html': {
+            title: 'SPA API',
+            body: `
+              <h1>API</h1>
+              <ul>
+                <li><a href="${basePath}index.html" data-route="index.html">Back to the index</a></li>
+                <li><a href="${basePath}guide.html" data-route="guide.html">Go to the guide</a></li>
+              </ul>
+              <div class="filler"></div>
+            `,
+          },
+        }
+
+        /** The page key for a path, tolerating the directory form of an address. */
+        const pageOf = (pathname) => {
+          const requested = pathname.slice(basePath.length).replace(/\/$/, '')
+          if (requested === '') {
+            return 'index.html'
+          }
+          return pages[requested] ? requested : pages[`${requested}.html`] ? `${requested}.html` : 'index.html'
+        }
+
+        // Pages published as directories, the way Docusaurus publishes every page: reaching one
+        // without its trailing slash normalizes the address in place, so the address the frame ends
+        // up on is not the one it was asked to load.
+        const publishedAsDirectory = (path) =>
+          path.startsWith(basePath) &&
+          path.length > basePath.length &&
+          !path.endsWith('/') &&
+          !path.slice(basePath.length).includes('.')
+        if (publishedAsDirectory(window.location.pathname)) {
+          window.history.replaceState(
+            {},
+            '',
+            `${window.location.pathname}/${window.location.search}${window.location.hash}`
+          )
+        }
+
+        const render = () => {
+          const page = pageOf(window.location.pathname)
+          const { title, body } = pages[page]
+          document.title = title
+          document.getElementById('app').innerHTML = `<div class="page" data-page="${page}">${body}</div>`
+          // Client-side routers scroll to the top of the new page themselves.
+          window.scrollTo(0, 0)
+        }
+
+        // Delegated on the app root rather than on the document, which is where a component based
+        // router ends up listening. Only the links this application owns are routed; everything
+        // else is left for the browser, and therefore for vdoc, to handle.
+        document.getElementById('app').addEventListener('click', (event) => {
+          const anchor = event.target.closest('a[data-route]')
+          if (anchor === null) {
+            return
+          }
+          event.preventDefault()
+          window.history.pushState({}, '', `${basePath}${anchor.dataset.route}`)
+          render()
+        })
+
+        window.addEventListener('popstate', render)
+        render()
+      })()
+    </script>
+  </body>
+</html>

--- a/tests/ui/resources/mockedSinglePageApp.html
+++ b/tests/ui/resources/mockedSinglePageApp.html
@@ -2,14 +2,29 @@
   <head>
     <!--
       Minimal stand-in for a single-page documentation generator (Docusaurus and friends): pages
-      are swapped in place with history.pushState, no document is discarded, and no `load` fires.
+      are swapped in place with history.pushState, no document is discarded, and no `load` fires,
+      and the color mode comes from the `vdoc-theme` parameter rather than from anything vdoc
+      writes into the document.
     -->
+    <script>
+      // The vdoc theme contract, applied before the first paint: read the requested mode, apply it
+      // the way this generator happens to apply modes, and declare that it was honored.
+      ;(() => {
+        const mode = new URLSearchParams(window.location.search).get('vdoc-theme') === 'dark' ? 'dark' : 'light'
+        document.documentElement.setAttribute('data-theme', mode)
+        document.documentElement.setAttribute('data-vdoc-theme', mode)
+      })()
+    </script>
     <style>
       body {
         background-color: rgb(227, 242, 253);
         color: black;
         margin: 0;
         font-family: sans-serif;
+      }
+      html[data-theme='dark'] body {
+        background-color: rgb(18, 18, 18);
+        color: white;
       }
       .page {
         padding: 16px;
@@ -40,6 +55,11 @@
                   <a href="${basePath}index.html?tab=examples" data-route="index.html?tab=examples">
                     Go to the index with a search parameter
                   </a>
+                </li>
+                <li>
+                  <!-- No data-route: the application leaves this one to the browser, the way a
+                       plain anchor in MDX ends up outside a component based router. -->
+                  <a href="${basePath}guide.html">Open the guide with a plain link</a>
                 </li>
                 <li><a href="/static/projects/example-project-02/1.0.0/index.html">Go to another project</a></li>
                 <li><a href="https://example.com/" target="_blank">Go to an external site</a></li>

--- a/tests/ui/resources/mockedSinglePageApp.html
+++ b/tests/ui/resources/mockedSinglePageApp.html
@@ -7,12 +7,20 @@
       writes into the document.
     -->
     <script>
-      // The vdoc theme contract, applied before the first paint: read the requested mode, apply it
-      // the way this generator happens to apply modes, and declare that it was honored.
+      // The vdoc frame contract, applied before the first paint: read the requested mode, apply it
+      // the way this generator happens to apply modes, and declare that it was honored. Then take
+      // the host's content inset, if it sent one, and line this page's header up with it.
       ;(() => {
-        const mode = new URLSearchParams(window.location.search).get('vdoc-theme') === 'dark' ? 'dark' : 'light'
+        const params = new URLSearchParams(window.location.search)
+        const mode = params.get('vdoc-theme') === 'dark' ? 'dark' : 'light'
         document.documentElement.setAttribute('data-theme', mode)
         document.documentElement.setAttribute('data-vdoc-theme', mode)
+
+        const inset = Number.parseInt(params.get('vdoc-inset') ?? '', 10)
+        if (Number.isFinite(inset)) {
+          document.documentElement.style.setProperty('--vdoc-inset', `${inset}px`)
+          document.documentElement.setAttribute('data-vdoc-inset-applied', String(inset))
+        }
       })()
     </script>
     <style>
@@ -28,6 +36,10 @@
       }
       .page {
         padding: 16px;
+      }
+      /* Falls back to the generator's own gutter when the host sends no inset. */
+      .page > h1 {
+        margin-left: var(--vdoc-inset, 0px);
       }
       .filler {
         height: 1200px;

--- a/tests/ui/testPageNavigationRace.spec.ts
+++ b/tests/ui/testPageNavigationRace.spec.ts
@@ -43,8 +43,11 @@ test('Navigating from a hashed URL to another page must not bounce back (BUGS-76
   // Track every page that gets (re-)loaded into the iframe from now on
   const iframeLoads: string[] = []
   page.on('request', (request) => {
-    if (request.url().includes('/static/projects/') && request.url().endsWith('.html')) {
-      iframeLoads.push(new URL(request.url()).pathname)
+    // Matched on the path alone: the frame is loaded with vdoc's `vdoc-theme` parameter appended,
+    // so the request URL does not end in `.html`.
+    const { pathname } = new URL(request.url())
+    if (pathname.includes('/static/projects/') && pathname.endsWith('.html')) {
+      iframeLoads.push(pathname)
     }
   })
 

--- a/tests/ui/testSinglePageApplication.spec.ts
+++ b/tests/ui/testSinglePageApplication.spec.ts
@@ -129,6 +129,24 @@ test('Toggling the color mode keeps the reader where they were', async ({ page }
   await expect.poll(async () => await iframeScrollY(page)).toBe(700)
 })
 
+test('The frame is told where vdocs own content starts', async ({ page }) => {
+  // GIVEN: A single page documentation that implements the content inset half of the contract
+  const documentation = await openSinglePageApp(page)
+
+  // THEN: It was told an inset, and it is the one vdoc's own header actually uses - measured here
+  // rather than asserted as a constant, because a hardcoded number on either side is the thing the
+  // parameter exists to remove
+  const headerInset = await page.getByTestId(testIDs.header.main).evaluate((header: HTMLElement) => {
+    const toolbar = header.firstElementChild as HTMLElement
+    return Math.round(Number.parseFloat(window.getComputedStyle(toolbar).paddingLeft))
+  })
+  expect(headerInset).toBeGreaterThan(0)
+  await expect(documentation).toHaveAttribute('data-vdoc-inset-applied', String(headerInset))
+
+  // AND: The parameter stays out of vdoc's own address bar, like the mode
+  await expect(page).toHaveURL(BASE_PATH)
+})
+
 test('A raw link keeps the frame inside the contract', async ({ page }) => {
   // GIVEN: A single page documentation in dark mode, and a link the application does not route
   // itself - a plain anchor in the markup, which the browser follows natively
@@ -179,6 +197,17 @@ test('Client-side navigation does not look the version up again', async ({ page 
   // GIVEN: An open single page documentation
   const documentation = await openSinglePageApp(page)
   const versionLookups = recordVersionLookups(page)
+
+  // AND: The header's own version fetches settled. They are not the route loader's, but they hit the
+  // same endpoints, so counting them would make this test about page load timing instead.
+  await expect
+    .poll(async () => {
+      const before = versionLookups.length
+      await page.waitForTimeout(300)
+      return versionLookups.length === before
+    })
+    .toBe(true)
+  versionLookups.length = 0
 
   // WHEN: The application turns the page, which changes the splat and nothing else
   await documentation.getByRole('link', { name: 'Go to the guide' }).click()

--- a/tests/ui/testSinglePageApplication.spec.ts
+++ b/tests/ui/testSinglePageApplication.spec.ts
@@ -1,8 +1,17 @@
 import fs from 'node:fs'
 import { expect, type Locator, type Page } from '@playwright/test'
+import type { EffectiveColorMode } from '../../src/ui/interfacesAndTypes/ColorModes'
 import testIDs from '../../src/ui/interfacesAndTypes/testIDs'
-import test, { prepareTestSuite } from './base'
-import { assertLinkOpensInNewTab, BASE_URL, openProjectDocumentation } from './helpers'
+import test, { prepareTestSuite, themes } from './base'
+import {
+  assertLinkOpensInNewTab,
+  assertTheme,
+  BASE_URL,
+  openProjectDocumentation,
+  openSettingsSidebar,
+  scrollIframe,
+  switchColorMode,
+} from './helpers'
 
 await prepareTestSuite(test)
 
@@ -48,6 +57,94 @@ const framedDocumentMarker = async (documentation: Locator): Promise<unknown> =>
   await documentation.evaluate(
     (html: HTMLElement) => (html.ownerDocument.defaultView as unknown as Record<string, unknown>).__vdocTestMarker
   )
+
+const iframeScrollY = async (page: Page): Promise<number> =>
+  await page
+    .getByTestId(testIDs.project.documentation.documentationIframe)
+    .evaluate((iframe: HTMLIFrameElement) => iframe.contentWindow?.scrollY ?? 0)
+
+const colorModes: EffectiveColorMode[] = ['light', 'dark']
+
+colorModes.forEach((colorMode: EffectiveColorMode) => {
+  test(`Single page app opens in the ${colorMode} mode on the very first visit`, async ({ page }) => {
+    // GIVEN: A reader whose preferred color scheme is ``colorMode`` and who has never been here
+    await page.emulateMedia({ colorScheme: colorMode })
+
+    // WHEN: They open a single page documentation
+    const documentation = await openSinglePageApp(page)
+
+    // THEN: It is displayed in that mode, without any stored preference being needed
+    await assertTheme(page, colorMode)
+
+    // AND: It declares that it applied the mode itself
+    await expect(documentation).toHaveAttribute('data-vdoc-theme', colorMode)
+
+    // AND: The parameter vdoc used to request it stays out of vdoc's own address bar
+    await expect(page).toHaveURL(BASE_PATH)
+  })
+})
+
+test('Toggling the color mode changes the single page app', async ({ page }) => {
+  // GIVEN: A single page documentation in light mode
+  await page.emulateMedia({ colorScheme: 'light' })
+  const documentation = await openSinglePageApp(page)
+  await assertTheme(page, 'light')
+
+  // WHEN: The reader switches to dark mode
+  await switchColorMode(page, 'dark')
+
+  // THEN: The documentation follows, and says so
+  await assertTheme(page, 'dark')
+  await expect(documentation).toHaveAttribute('data-vdoc-theme', 'dark')
+
+  // AND: Back again
+  await switchColorMode(page, 'light')
+  await assertTheme(page, 'light')
+  await expect(documentation).toHaveAttribute('data-vdoc-theme', 'light')
+
+  // AND: The address bar never picked up the parameter vdoc uses to request the mode
+  await expect(page).toHaveURL(BASE_PATH)
+})
+
+test('Toggling the color mode keeps the reader where they were', async ({ page }) => {
+  // GIVEN: A reader part way down a single page documentation in light mode
+  await page.emulateMedia({ colorScheme: 'light' })
+  const documentation = await openSinglePageApp(page)
+
+  // AND: The settings sidebar already open, because scrolling down hides the header
+  await openSettingsSidebar(page)
+
+  const iframe = page.getByTestId(testIDs.project.documentation.documentationIframe)
+  await scrollIframe(iframe, 700)
+  await expect.poll(async () => await iframeScrollY(page)).toBe(700)
+
+  // WHEN: They switch to dark mode, which the frame can only apply by reloading
+  await page.getByTestId(testIDs.sidebar.settings.toggleColorModes.buttons.dark).click()
+
+  // THEN: The documentation is reloaded in dark mode
+  await expect(documentation).toHaveAttribute('data-vdoc-theme', 'dark')
+  await expect(documentation.locator('body')).toHaveCSS('background-color', themes.dark.backgroundColor)
+
+  // AND: The reader is still where they were, rather than back at the top
+  await expect.poll(async () => await iframeScrollY(page)).toBe(700)
+})
+
+test('A raw link keeps the frame inside the contract', async ({ page }) => {
+  // GIVEN: A single page documentation in dark mode, and a link the application does not route
+  // itself - a plain anchor in the markup, which the browser follows natively
+  await page.emulateMedia({ colorScheme: 'dark' })
+  const documentation = await openSinglePageApp(page)
+  await expect(documentation).toHaveAttribute('data-vdoc-theme', 'dark')
+
+  // WHEN: The reader follows it, so vdoc navigates the frame rather than the router
+  await documentation.getByRole('link', { name: 'Open the guide with a plain link' }).click()
+  await expect(page).toHaveURL(`${BASE_PATH}/guide.html`)
+
+  // THEN: The new document was asked for the mode too, so it still declares the attribute and the
+  // reader does not land on a light page with vdoc's own header still dark
+  await expect(documentation).toHaveAttribute('data-vdoc-theme', 'dark')
+  await assertTheme(page, 'dark')
+})
 
 test('Client-side navigation updates the address bar and the title without reloading', async ({ page }) => {
   // GIVEN: A single page documentation whose window is marked

--- a/tests/ui/testSinglePageApplication.spec.ts
+++ b/tests/ui/testSinglePageApplication.spec.ts
@@ -163,6 +163,39 @@ test('Client-side navigation updates the address bar and the title without reloa
   expect(await framedDocumentMarker(documentation)).toBe('kept')
 })
 
+/** Every request the route loader's version lookup makes, in order. */
+const recordVersionLookups = (page: Page): string[] => {
+  const lookups: string[] = []
+  page.on('request', (request) => {
+    const { pathname } = new URL(request.url())
+    if (pathname.includes('/api/projects/') && pathname.includes('/versions/')) {
+      lookups.push(pathname)
+    }
+  })
+  return lookups
+}
+
+test('Client-side navigation does not look the version up again', async ({ page }) => {
+  // GIVEN: An open single page documentation
+  const documentation = await openSinglePageApp(page)
+  const versionLookups = recordVersionLookups(page)
+
+  // WHEN: The application turns the page, which changes the splat and nothing else
+  await documentation.getByRole('link', { name: 'Go to the guide' }).click()
+  await expect(page).toHaveURL(`${BASE_PATH}/guide.html`)
+  await expect(renderedPage(documentation)).toHaveAttribute('data-page', 'guide.html')
+
+  // AND: A second time, to catch a lookup that only happens from the second page on
+  await documentation.getByRole('link', { name: 'Go to the API' }).click()
+  await expect(page).toHaveURL(`${BASE_PATH}/api.html`)
+  await page.waitForTimeout(500)
+
+  // THEN: Nothing was looked up. Which version is being read depends on the project and the
+  // version, never on the page, and a loader that re-runs per page turn puts two sequential HTTP
+  // round trips in front of every click a reader makes inside the frame.
+  expect(versionLookups).toStrictEqual([])
+})
+
 test('Reloading vdoc at a client-side navigated address returns the same page', async ({ page }) => {
   // GIVEN: A reader who navigated to the API page client-side
   const documentation = await openSinglePageApp(page)

--- a/tests/ui/testSinglePageApplication.spec.ts
+++ b/tests/ui/testSinglePageApplication.spec.ts
@@ -1,0 +1,197 @@
+import fs from 'node:fs'
+import { expect, type Locator, type Page } from '@playwright/test'
+import testIDs from '../../src/ui/interfacesAndTypes/testIDs'
+import test, { prepareTestSuite } from './base'
+import { assertLinkOpensInNewTab, BASE_URL, openProjectDocumentation } from './helpers'
+
+await prepareTestSuite(test)
+
+const BASE_PATH = `${BASE_URL}/example-project-01/3.2.0`
+
+/**
+ * Serves the single page application fixture for every page of example-project-01.
+ *
+ * Registered inside the test body so that it takes priority over the catch-all route from
+ * ``prepareTestSuite``, which serves the static documentation fixture.
+ */
+const serveSinglePageApp = async (page: Page) => {
+  // A regular expression rather than a glob, so that a trailing slash or a query string cannot make
+  // a request fall through to the dev server, which answers anything it does not know with vdoc's
+  // own application - inside the frame that reads as a documentation page and recurses.
+  await page.route(/\/static\/projects\/example-project-01\//, (route) =>
+    route.fulfill({
+      contentType: 'text/html',
+      body: fs.readFileSync('tests/ui/resources/mockedSinglePageApp.html'),
+    })
+  )
+}
+
+const openSinglePageApp = async (page: Page): Promise<Locator> => {
+  await serveSinglePageApp(page)
+  return await openProjectDocumentation(page, 'example-project-01', 'latest', '3.2.0')
+}
+
+/** The page the fixture currently renders, as opposed to the one the address bar names. */
+const renderedPage = (documentation: Locator): Locator => documentation.locator('[data-page]')
+
+/**
+ * Marks the framed window, so that a later check can tell a client-side navigation from one that
+ * discarded the document.
+ */
+const markFramedDocument = async (documentation: Locator) => {
+  await documentation.evaluate((html: HTMLElement) => {
+    ;(html.ownerDocument.defaultView as unknown as Record<string, unknown>).__vdocTestMarker = 'kept'
+  })
+}
+
+const framedDocumentMarker = async (documentation: Locator): Promise<unknown> =>
+  await documentation.evaluate(
+    (html: HTMLElement) => (html.ownerDocument.defaultView as unknown as Record<string, unknown>).__vdocTestMarker
+  )
+
+test('Client-side navigation updates the address bar and the title without reloading', async ({ page }) => {
+  // GIVEN: A single page documentation whose window is marked
+  const documentation = await openSinglePageApp(page)
+  await markFramedDocument(documentation)
+
+  // WHEN: The reader clicks a link the application routes itself
+  await documentation.getByRole('link', { name: 'Go to the guide' }).click()
+
+  // THEN: vdoc's address bar and the browser title follow
+  await expect(page).toHaveURL(`${BASE_PATH}/guide.html`)
+  await expect(page).toHaveTitle('SPA Guide')
+  await expect(renderedPage(documentation)).toHaveAttribute('data-page', 'guide.html')
+
+  // AND: No document was discarded on the way, so this really was client-side routing
+  expect(await framedDocumentMarker(documentation)).toBe('kept')
+})
+
+test('Reloading vdoc at a client-side navigated address returns the same page', async ({ page }) => {
+  // GIVEN: A reader who navigated to the API page client-side
+  const documentation = await openSinglePageApp(page)
+  await documentation.getByRole('link', { name: 'Go to the API' }).click()
+  await expect(page).toHaveURL(`${BASE_PATH}/api.html`)
+
+  // WHEN: They reload, or share the address and someone else opens it
+  await page.reload()
+  await page.waitForLoadState()
+
+  // THEN: The same page comes back
+  await expect(page).toHaveURL(`${BASE_PATH}/api.html`)
+  await expect(renderedPage(documentation)).toHaveAttribute('data-page', 'api.html')
+  await expect(page).toHaveTitle('SPA API')
+})
+
+test('In-frame back and forward are followed by the address bar', async ({ page }) => {
+  // GIVEN: A reader who walked through two pages client-side
+  const documentation = await openSinglePageApp(page)
+  await documentation.getByRole('link', { name: 'Go to the guide' }).click()
+  await expect(page).toHaveURL(`${BASE_PATH}/guide.html`)
+  await documentation.getByRole('link', { name: 'Go to the API' }).click()
+  await expect(page).toHaveURL(`${BASE_PATH}/api.html`)
+
+  // WHEN: They go back
+  await page.goBack()
+
+  // THEN: Both the rendered page and the address bar are one step back, after a single click
+  await expect(page).toHaveURL(`${BASE_PATH}/guide.html`)
+  await expect(renderedPage(documentation)).toHaveAttribute('data-page', 'guide.html')
+
+  // WHEN: They go back once more
+  await page.goBack()
+
+  // THEN: They are on the page they started from
+  await expect(page).toHaveURL(BASE_PATH)
+  await expect(renderedPage(documentation)).toHaveAttribute('data-page', 'index.html')
+
+  // WHEN: They go forward again
+  await page.goForward()
+
+  // THEN: The address bar and the rendered page follow
+  await expect(page).toHaveURL(`${BASE_PATH}/guide.html`)
+  await expect(renderedPage(documentation)).toHaveAttribute('data-page', 'guide.html')
+})
+
+test('In-page anchors are reflected in the address bar', async ({ page }) => {
+  // GIVEN: A reader on a client-side navigated page
+  const documentation = await openSinglePageApp(page)
+  await documentation.getByRole('link', { name: 'Go to the guide' }).click()
+  await expect(page).toHaveURL(`${BASE_PATH}/guide.html`)
+
+  const chapter2 = documentation.locator('#chapter2')
+  await expect(chapter2).not.toBeInViewport()
+
+  // WHEN: They jump to a chapter within that page
+  await documentation.getByRole('link', { name: 'Jump to chapter 2' }).click()
+
+  // THEN: The hash is in vdoc's address bar and the chapter is on screen, rather than the reader
+  // being sent back to the top of the page
+  await expect(page).toHaveURL(`${BASE_PATH}/guide.html#chapter2`)
+  await expect(chapter2).toBeInViewport()
+})
+
+test('Search parameters of a client-side navigation reach vdocs address bar', async ({ page }) => {
+  // GIVEN: A single page documentation
+  const documentation = await openSinglePageApp(page)
+
+  // WHEN: The application routes to a page with a search parameter
+  await documentation.getByRole('link', { name: 'Go to the index with a search parameter' }).click()
+
+  // THEN: The parameter shows up in vdoc's address bar
+  await expect(page).toHaveURL(`${BASE_PATH}/index.html?tab=examples`)
+})
+
+test('A page published as a directory is not reloaded in a loop', async ({ page }) => {
+  // GIVEN: A page published as a directory, the way Docusaurus publishes every page: requesting it
+  // without the trailing slash normalizes the address to the form with one, while the slash is not
+  // part of the splat vdoc's own router parses back out of its address bar
+  await serveSinglePageApp(page)
+
+  let documentLoads = 0
+  page.on('request', (request) => {
+    if (request.resourceType() === 'document' && request.url().includes('/static/projects/')) {
+      documentLoads += 1
+    }
+  })
+
+  // WHEN: The reader opens that page
+  await page.goto(`${BASE_PATH}/guide`)
+  await page.waitForLoadState()
+  await page.waitForTimeout(3000)
+
+  // THEN: The frame was fetched once and settled, rather than reloading for as long as it is open
+  expect(documentLoads).toBeGreaterThan(0)
+  expect(documentLoads).toBeLessThanOrEqual(2)
+
+  // AND: The documentation is actually on screen
+  const documentation = page
+    .getByTestId(testIDs.project.documentation.documentationIframe)
+    .contentFrame()
+    .locator('html')
+  await expect(documentation.locator('h1')).toBeVisible()
+})
+
+test('Foreign links of a single page app open in a new tab', async ({ page }) => {
+  // GIVEN: A single page documentation
+  const documentation = await openSinglePageApp(page)
+
+  // WHEN/THEN: A link to another project opens in a new tab, at vdoc's readable address
+  const otherProject = await assertLinkOpensInNewTab(
+    page,
+    documentation.getByRole('link', { name: 'Go to another project' }),
+    `${BASE_URL}/example-project-02/1.0.0/index.html`
+  )
+  await otherProject.close()
+
+  // AND: So does an external link
+  const externalSite = await assertLinkOpensInNewTab(
+    page,
+    documentation.getByRole('link', { name: 'Go to an external site' }),
+    'https://example.com/'
+  )
+  await externalSite.close()
+
+  // AND: The frame itself stayed where it was
+  await expect(page).toHaveURL(BASE_PATH)
+  await expect(renderedPage(documentation)).toHaveAttribute('data-page', 'index.html')
+})

--- a/uv.lock
+++ b/uv.lock
@@ -1890,6 +1890,21 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinxcontrib-mermaid"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/9d/bf3a48a657682c7e0445c71d916bca7ab8194454276cc22b16e7f974e502/sphinxcontrib_mermaid-2.1.0.tar.gz", hash = "sha256:13c5f9ac395cb6abf403eca34e228dc9fb3a30c9d960dbf3e40e9a8cef969549", size = 21695, upload-time = "2026-07-18T23:08:11.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/bd/d3348d62296e73a91420f0edf671450c9003ecd8704da40b1e3d9b868459/sphinxcontrib_mermaid-2.1.0-py3-none-any.whl", hash = "sha256:417cd144ec4b28852f46ba653f02ce8e538881c812111671a4c30344e87f2112", size = 16190, upload-time = "2026-07-18T23:08:10.098Z" },
+]
+
+[[package]]
 name = "sphinxcontrib-qthelp"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2253,6 +2268,7 @@ dev = [
     { name = "sphinx-autodoc-typehints", version = "3.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sphinx-selective-exclude" },
     { name = "sphinxawesome-theme" },
+    { name = "sphinxcontrib-mermaid" },
     { name = "tenacity" },
     { name = "tox" },
     { name = "tox-uv" },
@@ -2275,6 +2291,7 @@ doc = [
     { name = "sphinx-autodoc-typehints", version = "3.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sphinx-selective-exclude" },
     { name = "sphinxawesome-theme" },
+    { name = "sphinxcontrib-mermaid" },
 ]
 doc-template = [
     { name = "doc8" },
@@ -2389,6 +2406,7 @@ dev = [
     { name = "sphinx-selective-exclude", specifier = "~=1.0" },
     { name = "sphinxawesome-theme" },
     { name = "sphinxawesome-theme", specifier = "~=6.0" },
+    { name = "sphinxcontrib-mermaid", specifier = "~=2.1" },
     { name = "tenacity" },
     { name = "tox", specifier = "~=4.0" },
     { name = "tox-uv", specifier = "~=1.0" },
@@ -2409,6 +2427,7 @@ doc = [
     { name = "sphinx-autodoc-typehints", specifier = "~=3.0" },
     { name = "sphinx-selective-exclude", specifier = "~=1.0" },
     { name = "sphinxawesome-theme", specifier = "~=6.0" },
+    { name = "sphinxcontrib-mermaid", specifier = "~=2.1" },
 ]
 doc-template = [
     { name = "doc8", specifier = "~=2.0" },


### PR DESCRIPTION
> **Meant for a rebase merge.** The six commits are each self-contained, conventionally typed and
> individually green, so they are worth keeping apart in `main` - `feat`, `fix`, `docs` and `build`
> land as their own changelog entries rather than as one squashed blob.

## Why

vdoc frames each published site and syncs its own interface - address bar, title, color-mode switch -
with the framed document. That sync assumed plain HTML: click a link, the browser discards the
document, the iframe fires `load`, vdoc re-reads everything. True for sphinx-awesome and doxygen.

Docusaurus, and any other single-page generator, breaks both halves. Pages are swapped in place with
`history.pushState`, so no `load` fires and vdoc's address bar keeps naming the page the reader
arrived on - sharing or reloading that URL brings back the wrong page. And the color-mode switch
reached into the framed document expecting `localStorage.darkMode` plus a Tailwind class, which
Docusaurus reads neither of, so the switch was simply inert.

Both were worked around inside `@voraus/docusaurus-theme`, at the cost of client-side routing, and
every future SPA-based docs project would have needed its own copy.

## The commits

| | |
| --- | --- |
| `feat(iframe)` | **Notice client-side navigation.** `report()` extracted from `onIframeLoad`; `history.pushState`/`replaceState` wrapped on the framed window, `popstate` observed, and the framed `<head>` watched for the title a client-side router sets after navigating. Both sides of the "is the frame already showing this?" comparison now reduce the address with one shared `normalizeIFrameSrc` - composing it differently on either side makes the sync effect fire on every navigation. A trailing slash is deliberately not part of that identity, because a generator that publishes pages as directories is reached through a redirect that adds one. |
| `build(docs)` | **Render mermaid diagrams.** `sphinxcontrib-mermaid` through the two extension points the project template provides. A bare ```` ```mermaid ```` fence would fail the build, since `sphinx-build -W` turns the missing Pygments lexer into an error. |
| `feat(iframe)` | **Apply the color mode through the frame URL.** `vdoc-theme=<light\|dark>` on the frame URL, unconditionally; a frame that understands it declares `data-vdoc-theme`. `applyColorMode` branches on that attribute, not on a guess about the generator - absent means today's instant class toggle, never a reload. Scroll position is preserved across the reload a participating frame needs. |
| `docs` | **The frame contract in one place.** It existed three times in prose across two repositories. |
| `fix(routing)` | **Resolve the version once per version, not once per page.** The loader sat on the page route, so turning a page inside the frame fired two sequential uncached requests for an answer that cannot have changed. Moved to a `/$projectName/$version` layout route: an in-frame navigation now makes no request at all. |
| `feat(iframe)` | **Tell the frame where vdoc's own content starts.** `vdoc-inset=<px>`, measured from vdoc's own `Toolbar` rather than hardcoded, so the theme can drop the 24px it had to assume. |

## No behaviour change for existing sites

The hard constraint was that sphinx-awesome and doxygen behave **exactly** as today. The assertions in
`testLinkSubstitution.spec.ts` and `testToggleColorMode.spec.ts` are unchanged, which is the check:
instant theme switching with no reload and no scroll jump, links working including cross-project and
external ones opening in a new tab, and the URL a reader hovers or copies staying the readable
`/<project>/<version>/…`.

That last one caught a real defect during review. A fragment-only link resolves against the whole
address of the document it sits in, so once the frame carried `?vdoc-theme=…`, every
`<a href="#section">` displayed and copied it. vdoc's parameters are now named once in
`VDOC_FRAME_PARAMS` and dropped by all three functions that turn a frame URL back into an address
vdoc shows or compares.

## Verifying

Unit 87, e2e 85, `tox -e docs` clean (doc8, pymarkdown, two `sphinx-build -W` runs), plus `tsc -b`,
biome, prettier, codespell, ruff and mypy.

The e2e suite was also run with two workers over three repeats, since a timing bug in a new test only
showed up under CI's worker count. Two regression locks were checked to actually fail without their
fix rather than merely passing with it: the version-lookup count (6 before, 0 after) and the link
addresses.

`tests/ui/resources/mockedSinglePageApp.html` is the stand-in for a single-page generator. It routes
on its own `data-route` rather than on the DOM `href`, the way a component-based router carries its
target in a prop - which is the assumption the link handling rests on, and the fixture makes it
explicit rather than quietly relying on it.

## The other side

`@voraus/docusaurus-theme` implements the contract and can be deployed independently of this PR;
`docs/frame_contract.md` here is numbered R1-R10 in step with that theme's own copy, so a review can
cite requirements across both repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)