### PR TITLE
feat(plugins): Let the theme plugin carry the palette and the shape

### DIFF
--- a/docs/plugins/theme.rst
+++ b/docs/plugins/theme.rst
@@ -1,40 +1,55 @@
 Theme Plugin
 ============
 
-**vdoc** can be extended with a theme plugin, which carries the logo the frontend shows. Its settings
-are given per color mode, because a logo that reads on a light background usually does not read on a
-dark one.
+**vdoc** can be extended with a theme plugin, which carries the logo and the colors the frontend uses.
+Most of its settings are given per color mode, because a value that reads on a light background usually
+does not read on a dark one.
+
+Every setting is optional, and leaving one unset keeps the framework's own default for it. An
+unconfigured instance therefore looks exactly as vdoc looks without the plugin, which is what keeps a
+generic build free of anybody's branding.
 
 Configuration
 -------------
 
-Under ``plugins.theme`` in the :ref:`configuration file <configuration-file>`, with a ``light`` and a
-``dark`` section:
+Under ``plugins.theme`` in the :ref:`configuration file <configuration-file>`:
 
 .. code-block:: yaml
 
    plugins:
      theme:
+       # Shape is not a property of a color mode, so it sits beside the two
+       border_radius: 0
+       flat_cards: true
+
        light:
          logo_url: https://example.com/logo.png
          logo_url_small: https://example.com/logo-small.png
+         palette:
+           primary: "#E133FF"
+           divider: "#E7E7EA"
+
        dark:
          logo_url: https://example.com/logo-negative.png
          logo_url_small: https://example.com/logo-small-negative.png
+         palette:
+           primary: "#00CFC6"
+           divider: "#2A2A30"
+           background_default: "#0C0C0E"
+           background_paper: "#0C0C0E"
 
 Every setting can equally be given as an environment variable, which then takes precedence over the
-file. Because these settings sit inside a color mode, the variable name has ``__`` between the two
-levels:
+file. Since these sit inside a color mode and, for the palette, one level deeper again, the variable
+name has ``__`` between the levels:
 
 .. code-block:: sh
 
+   VDOC_PLUGINS_THEME_BORDER_RADIUS=0
    VDOC_PLUGINS_THEME_LIGHT__LOGO_URL='https://example.com/logo.png'
-   VDOC_PLUGINS_THEME_DARK__LOGO_URL='https://example.com/logo-negative.png'
+   VDOC_PLUGINS_THEME_DARK__PALETTE__PRIMARY='#00CFC6'
 
 Settings
 --------
-
-Both are available under ``light`` and under ``dark``:
 
 .. list-table:: Theme Plugin Settings
    :header-rows: 1
@@ -42,17 +57,40 @@ Both are available under ``light`` and under ``dark``:
    * - Setting
      - Explanation
      - Default
-     - Example
-   * - ``logo_url``
+   * - ``border_radius``
+     - How round every corner is, in pixels. ``0`` for square.
+     - the framework's own
+   * - ``flat_cards``
+     - Whether cards are drawn as a plain outline instead of a raised surface.
+     - ``False``
+   * - ``<mode>.logo_url``
      - The URL of the logo to be used in the frontend.
      - ``https://logos.vorausrobotik.com/v_rgb.png``
-     - ``https://example.com/logo.png``
-   * - ``logo_url_small``
+   * - ``<mode>.logo_url_small``
      - The URL of the small logo, used where the viewport is too narrow for the full one.
      - ``https://logos.vorausrobotik.com/v_rgb.png``
-     - ``https://example.com/logo-small.png``
+   * - ``<mode>.palette.primary``
+     - The color of links, buttons and anything else the interface treats as actionable.
+     - the framework's own
+   * - ``<mode>.palette.divider``
+     - The color of borders and separators, including the outline of a card.
+     - the framework's own
+   * - ``<mode>.palette.background_default``
+     - The color of the page itself.
+     - the framework's own
+   * - ``<mode>.palette.background_paper``
+     - The color of surfaces on the page, such as cards.
+     - the framework's own
 
-The environment variable for a setting is ``VDOC_PLUGINS_THEME_<MODE>__`` followed by its name in
-upper case, where ``<MODE>`` is ``LIGHT`` or ``DARK``.
+``<mode>`` is ``light`` or ``dark``. A color has to be a CSS hex value such as ``#00CFC6``; anything
+else fails at startup rather than rendering as no color at all.
 
 Without a logo the frontend falls back to rendering the text ``vdoc`` in the app bar.
+
+Adding a palette value
+----------------------
+
+The palette deliberately exposes a small set rather than all of the framework's. Supporting one more is
+two lines: a field on ``ThemePalette`` in ``src/vdoc/models/plugins/theme.py``, and the line that maps
+it in ``paletteFor`` in ``src/ui/helpers/Theme.ts``. The names match the framework's own palette slots
+so that there is nothing to translate in between.

--- a/src/ui/components/MenuBar.tsx
+++ b/src/ui/components/MenuBar.tsx
@@ -9,25 +9,23 @@ import {
   useMediaQuery,
   useTheme,
 } from '@mui/material'
-import { useNavigate, useParams } from '@tanstack/react-router'
+import { getRouteApi, useNavigate, useParams } from '@tanstack/react-router'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useContentInset } from '../contexts/ContentInsetContext'
 import { fetchAppVersion, fetchPluginConfig, fetchProjectVersion, fetchProjectVersions } from '../helpers/APIFunctions'
 import type OramaPluginT from '../interfacesAndTypes/plugins/OramaPluginT'
-import type ThemePluginT from '../interfacesAndTypes/plugins/ThemePlugin'
 import testIDs from '../interfacesAndTypes/testIDs'
 import ColorModeToggle from './ColorModeToggle'
 import { OramaSearchPlugin } from './plugins/OramaSearchPlugin'
 import VersionDropdown from './VersionDropdown'
 
+const route = getRouteApi('__root__')
+
 function LeftGroup() {
   const theme = useTheme()
   const useSmallLogo = useMediaQuery(theme.breakpoints.down('lg'))
-  const [themePluginConfig, setThemePluginConfig] = useState<ThemePluginT | null>(null)
-
-  useEffect(() => {
-    fetchPluginConfig<ThemePluginT>('theme').then((config) => setThemePluginConfig(config))
-  }, [])
+  // Taken from the root loader, which resolves it before the first paint, rather than fetched here
+  const { themePluginConfig } = route.useLoaderData()
 
   const logoUrl = useMemo(() => {
     const smallLogoUrl = themePluginConfig?.[theme.palette.mode]?.logo_url_small

--- a/src/ui/components/RootLayout.tsx
+++ b/src/ui/components/RootLayout.tsx
@@ -1,20 +1,16 @@
-import { Box, CssBaseline, createTheme, Slide, ThemeProvider, useColorScheme } from '@mui/material'
+import { Box, CssBaseline, Slide, ThemeProvider, useColorScheme } from '@mui/material'
 import InitColorSchemeScript from '@mui/material/InitColorSchemeScript'
-import { Outlet } from '@tanstack/react-router'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { getRouteApi, Outlet } from '@tanstack/react-router'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ContentInsetProvider } from '../contexts/ContentInsetProvider'
 import { useIFrameScroll } from '../contexts/IFrameScrollContext'
 import { IFrameScrollProvider } from '../contexts/IFrameScrollProvider'
+import { buildTheme } from '../helpers/Theme'
 import MenuBar from './MenuBar'
 import { FooterPlugin } from './plugins/FooterPlugin'
 import ScrollToTop from './ScrollToTop'
 
-const theme = createTheme({
-  colorSchemes: {
-    light: true,
-    dark: true,
-  },
-})
+const route = getRouteApi('__root__')
 
 /**
  * Determines whether navigation elements should be hidden based on scroll behavior.
@@ -127,6 +123,9 @@ function ThemedComponent() {
 }
 
 export function RootComponent() {
+  const { themePluginConfig } = route.useLoaderData()
+  const theme = useMemo(() => buildTheme(themePluginConfig), [themePluginConfig])
+
   return (
     <ThemeProvider theme={theme} defaultMode="system">
       <CssBaseline />

--- a/src/ui/helpers/Theme.ts
+++ b/src/ui/helpers/Theme.ts
@@ -1,0 +1,41 @@
+import { createTheme, type PaletteOptions, type Theme } from '@mui/material/styles'
+import type { EffectiveColorMode } from '../interfacesAndTypes/ColorModes'
+import type ThemePluginT from '../interfacesAndTypes/plugins/ThemePlugin'
+
+/**
+ * Turns the theme plugin's configuration into a MUI theme.
+ *
+ * The one place that translates configuration into appearance. A value the plugin leaves unset is left
+ * out of the options entirely rather than passed as undefined, so MUI keeps its own default for it and
+ * an unconfigured instance looks exactly as it did before the plugin could say anything.
+ *
+ * Supporting another palette value is a field on the plugin and one line in `paletteFor` below.
+ */
+export function buildTheme(config: ThemePluginT | null): Theme {
+  return createTheme({
+    colorSchemes: {
+      light: { palette: paletteFor(config, 'light') },
+      dark: { palette: paletteFor(config, 'dark') },
+    },
+    ...(config?.border_radius != null && { shape: { borderRadius: config.border_radius } }),
+    ...(config?.flat_cards && {
+      // "No shadow, square, one pixel of border" is what MUI's outlined variant already is
+      components: { MuiCard: { defaultProps: { variant: 'outlined' as const } } },
+    }),
+  })
+}
+
+function paletteFor(config: ThemePluginT | null, mode: EffectiveColorMode): PaletteOptions {
+  const palette = config?.[mode]?.palette
+
+  return {
+    ...(palette?.primary && { primary: { main: palette.primary } }),
+    ...(palette?.divider && { divider: palette.divider }),
+    ...((palette?.background_default || palette?.background_paper) && {
+      background: {
+        ...(palette.background_default && { default: palette.background_default }),
+        ...(palette.background_paper && { paper: palette.background_paper }),
+      },
+    }),
+  }
+}

--- a/src/ui/interfacesAndTypes/plugins/ThemePlugin.ts
+++ b/src/ui/interfacesAndTypes/plugins/ThemePlugin.ts
@@ -1,13 +1,23 @@
 import type { PluginBaseT } from './PluginBase'
 
+type ThemePaletteT = {
+  primary?: string | null
+  divider?: string | null
+  background_default?: string | null
+  background_paper?: string | null
+}
+
 type ThemeSettingsT = {
   logo_url?: string
   logo_url_small?: string
+  palette?: ThemePaletteT
 }
 
 type ThemePluginFields = {
   light: ThemeSettingsT
   dark: ThemeSettingsT
+  border_radius: number | null
+  flat_cards: boolean
 }
 
 export type ThemePluginT = PluginBaseT<ThemePluginFields>

--- a/src/ui/routes/__root.tsx
+++ b/src/ui/routes/__root.tsx
@@ -1,7 +1,16 @@
 import { createRootRoute } from '@tanstack/react-router'
 
 import { RootComponent } from '../components/RootLayout'
+import { fetchPluginConfig } from '../helpers/APIFunctions'
+import type ThemePluginT from '../interfacesAndTypes/plugins/ThemePlugin'
 
 export const Route = createRootRoute({
+  // Resolved before anything paints, because the palette decides how the whole interface looks and a
+  // theme arriving afterwards would repaint it. This replaces the fetch the app bar used to do for its
+  // logo, so it costs no additional request and the logo stops appearing a moment late as well.
+  //
+  // Caught: a theme that cannot be read leaves the framework's own defaults in place, which is worth
+  // more than an interface that refuses to render.
+  loader: async () => ({ themePluginConfig: await fetchPluginConfig<ThemePluginT>('theme').catch(() => null) }),
   component: RootComponent,
 })

--- a/src/vdoc/models/plugins/theme.py
+++ b/src/vdoc/models/plugins/theme.py
@@ -1,9 +1,37 @@
 """Contains the theme plugin."""
 
-from pydantic import AnyHttpUrl, BaseModel
+from typing import Annotated
+
+from pydantic import AnyHttpUrl, BaseModel, StringConstraints
 
 from vdoc.constants import PLUGIN_THEME_DEFAULT_LOGO_URL, PLUGIN_THEME_DEFAULT_LOGO_URL_SMALL
 from vdoc.models.plugins.base import Plugin, ValidPluginsT
+
+HexColor = Annotated[str, StringConstraints(pattern=r"^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")]
+"""A CSS hex color. Validated so that a typo fails at startup rather than rendering as nothing."""
+
+
+class ThemePalette(BaseModel):
+    """The palette values a deployment may set, per color mode.
+
+    The names are the frontend's own palette slots, so there is nothing to translate between this and
+    what is handed to the theme. Every value is optional, and ``None`` means "leave the framework's own
+    default alone" -- which is what keeps vdoc unbranded until somebody says otherwise.
+
+    Adding another value is a field here and one line in the frontend's theme builder.
+    """
+
+    primary: HexColor | None = None
+    """The color of links, buttons and anything else the interface treats as actionable."""
+
+    divider: HexColor | None = None
+    """The color of borders and separators, including the outline of a card."""
+
+    background_default: HexColor | None = None
+    """The color of the page itself."""
+
+    background_paper: HexColor | None = None
+    """The color of surfaces on the page, such as cards."""
 
 
 class ThemeSettings(BaseModel):
@@ -11,6 +39,7 @@ class ThemeSettings(BaseModel):
 
     logo_url: AnyHttpUrl | None = PLUGIN_THEME_DEFAULT_LOGO_URL
     logo_url_small: AnyHttpUrl | None = PLUGIN_THEME_DEFAULT_LOGO_URL_SMALL
+    palette: ThemePalette = ThemePalette()
 
 
 class ThemePlugin(Plugin):
@@ -20,6 +49,13 @@ class ThemePlugin(Plugin):
 
     light: ThemeSettings = ThemeSettings()
     dark: ThemeSettings = ThemeSettings()
+
+    # Shape is not a property of a color mode, so these sit beside the two rather than inside them.
+    border_radius: int | None = None
+    """How round every corner is, in pixels. ``0`` for square."""
+
+    flat_cards: bool = False
+    """Whether cards are drawn as a plain outline instead of a raised surface."""
 
     @property
     def active(self) -> bool:

--- a/tests/ui/base.ts
+++ b/tests/ui/base.ts
@@ -103,13 +103,17 @@ export const mockAPIRequests = async (page: Page) => {
         json: {
           name: 'theme',
           active: true,
+          border_radius: null,
+          flat_cards: false,
           light: {
             logo_url: 'https://logos.vorausrobotik.com/voraus-robotik_farbig_rgb.png',
             logo_url_small: 'https://logos.vorausrobotik.com/v_rgb.png',
+            palette: {},
           },
           dark: {
             logo_url: 'https://logos.vorausrobotik.com/voraus-robotik_farbig_negativ_rgb.png',
             logo_url_small: 'https://logos.vorausrobotik.com/v_rgb.png',
+            palette: {},
           },
         },
       },

--- a/tests/ui/plugins/testThemePlugin.spec.ts
+++ b/tests/ui/plugins/testThemePlugin.spec.ts
@@ -1,29 +1,56 @@
-import type { EffectiveColorMode } from '../../../src/ui/interfacesAndTypes/ColorModes'
+import { expect } from '@playwright/test'
+import testIDs from '../../../src/ui/interfacesAndTypes/testIDs'
 import test, { prepareTestSuite } from '../base'
-import { assertMenuBar, BASE_URL } from '../helpers'
 
 await prepareTestSuite(test)
 
-test.describe('Theme plugin tests', () => {
-  const mockedPluginPayload = {
-    name: 'theme',
-    active: true,
-    light: {
-      logo_url: 'https://example.com/logo_light.png',
-    },
-    dark: {
-      logo_url: 'https://example.com/logo_dark.png',
-    },
-  }
-  const effectiveColorModes: EffectiveColorMode[] = ['dark', 'light']
-  effectiveColorModes.forEach((preferredColorScheme: EffectiveColorMode) => {
-    test(`Theme plugin works as expected in ${preferredColorScheme} mode`, async ({ page }) => {
-      await page.route('*/**/api/plugins/theme/', (route) => route.fulfill({ json: mockedPluginPayload }))
+const configured = {
+  name: 'theme',
+  active: true,
+  border_radius: 0,
+  flat_cards: true,
+  light: { palette: { primary: '#E133FF', divider: '#E7E7EA' } },
+  dark: { palette: { primary: '#00CFC6', divider: '#2A2A30', background_default: '#0C0C0E' } },
+}
 
-      await page.emulateMedia({ colorScheme: preferredColorScheme })
+test.describe('Theme plugin palette', () => {
+  test('colors the actionable elements per color mode', async ({ page }) => {
+    await page.route('*/**/api/plugins/theme/', (route) => route.fulfill({ json: configured }))
+
+    for (const [mode, expected] of [
+      ['light', 'rgb(225, 51, 255)'],
+      ['dark', 'rgb(0, 207, 198)'],
+    ] as const) {
+      await page.emulateMedia({ colorScheme: mode })
       await page.goto('/')
-      await page.waitForLoadState()
-      await assertMenuBar(page, `${BASE_URL}/`, mockedPluginPayload[preferredColorScheme].logo_url)
-    })
+      const link = page
+        .getByTestId(
+          testIDs.landingPage.projectCategories.projectCategory.projects.projectCard.actions.documentationLink
+        )
+        .first()
+      await expect(link).toHaveCSS('color', expected)
+    }
+  })
+
+  test('squares the corners and outlines the cards', async ({ page }) => {
+    await page.route('*/**/api/plugins/theme/', (route) => route.fulfill({ json: configured }))
+    await page.goto('/')
+
+    const card = page
+      .getByTestId(testIDs.landingPage.projectCategories.projectCategory.projects.projectCard.main)
+      .first()
+    await expect(card).toHaveCSS('border-radius', '0px')
+    await expect(card).toHaveCSS('box-shadow', 'none')
+    await expect(card).toHaveCSS('border-top-width', '1px')
+  })
+
+  test('leaves the framework defaults alone when nothing is configured', async ({ page }) => {
+    await page.goto('/')
+
+    const card = page
+      .getByTestId(testIDs.landingPage.projectCategories.projectCategory.projects.projectCard.main)
+      .first()
+    // MUI's own default radius, which an unconfigured instance has to keep
+    await expect(card).toHaveCSS('border-radius', '4px')
   })
 })

--- a/tests/unit/api/routes/plugins/test_load_routers.py
+++ b/tests/unit/api/routes/plugins/test_load_routers.py
@@ -31,13 +31,27 @@ def test_plugin_routers_are_added(load_plugins_mock: MagicMock, request: pytest.
     assert api.get("/api/plugins/theme/").json() == {
         "name": "theme",
         "active": True,
+        "border_radius": None,
+        "flat_cards": False,
         "dark": {
             "logo_url": str(PLUGIN_THEME_DEFAULT_LOGO_URL),
             "logo_url_small": str(PLUGIN_THEME_DEFAULT_LOGO_URL_SMALL),
+            "palette": {
+                "primary": None,
+                "divider": None,
+                "background_default": None,
+                "background_paper": None,
+            },
         },
         "light": {
             "logo_url": str(PLUGIN_THEME_DEFAULT_LOGO_URL),
             "logo_url_small": str(PLUGIN_THEME_DEFAULT_LOGO_URL_SMALL),
+            "palette": {
+                "primary": None,
+                "divider": None,
+                "background_default": None,
+                "background_paper": None,
+            },
         },
     }
 

--- a/tests/unit/api/routes/plugins/test_theme_plugin_routes.py
+++ b/tests/unit/api/routes/plugins/test_theme_plugin_routes.py
@@ -11,10 +11,24 @@ def test_get_theme_config(api: TestClient) -> None:
         "light": {
             "logo_url": str(PLUGIN_THEME_DEFAULT_LOGO_URL),
             "logo_url_small": str(PLUGIN_THEME_DEFAULT_LOGO_URL_SMALL),
+            "palette": {
+                "primary": None,
+                "divider": None,
+                "background_default": None,
+                "background_paper": None,
+            },
         },
         "dark": {
             "logo_url": str(PLUGIN_THEME_DEFAULT_LOGO_URL),
             "logo_url_small": str(PLUGIN_THEME_DEFAULT_LOGO_URL_SMALL),
+            "palette": {
+                "primary": None,
+                "divider": None,
+                "background_default": None,
+                "background_paper": None,
+            },
         },
+        "border_radius": None,
+        "flat_cards": False,
         "active": True,
     }

--- a/tests/unit/models/plugins/test_theme_plugin.py
+++ b/tests/unit/models/plugins/test_theme_plugin.py
@@ -3,8 +3,10 @@
 import os
 from unittest.mock import patch
 
-from pydantic import AnyHttpUrl
+import pytest
+from pydantic import AnyHttpUrl, ValidationError
 
+from vdoc.constants import CONFIG_ENV_PREFIX_PLUGINS
 from vdoc.models.plugins import ThemePlugin
 
 
@@ -35,3 +37,40 @@ def test_theme_plugin_from_env() -> None:
     assert plugin.light.logo_url_small == AnyHttpUrl("https://small-light.com")
     assert plugin.dark.logo_url == AnyHttpUrl("https://dark.com")
     assert plugin.dark.logo_url_small == AnyHttpUrl("https://small-dark.com")
+
+
+@patch.dict(
+    os.environ,
+    {
+        f"{CONFIG_ENV_PREFIX_PLUGINS}THEME_LIGHT__PALETTE__PRIMARY": "#E133FF",
+        f"{CONFIG_ENV_PREFIX_PLUGINS}THEME_DARK__PALETTE__PRIMARY": "#00CFC6",
+        f"{CONFIG_ENV_PREFIX_PLUGINS}THEME_DARK__PALETTE__BACKGROUND_DEFAULT": "#0C0C0E",
+        f"{CONFIG_ENV_PREFIX_PLUGINS}THEME_BORDER_RADIUS": "0",
+        f"{CONFIG_ENV_PREFIX_PLUGINS}THEME_FLAT_CARDS": "True",
+    },
+)
+def test_theme_plugin_palette_from_env() -> None:
+    plugin = ThemePlugin()
+
+    assert plugin.light.palette.primary == "#E133FF"
+    assert plugin.dark.palette.primary == "#00CFC6"
+    assert plugin.dark.palette.background_default == "#0C0C0E"
+    assert plugin.border_radius == 0
+    assert plugin.flat_cards is True
+
+
+def test_theme_plugin_palette_defaults_to_nothing() -> None:
+    """An unconfigured palette has to leave every framework default in place."""
+    plugin = ThemePlugin()
+
+    assert plugin.light.palette.model_dump(exclude_none=True) == {}
+    assert plugin.dark.palette.model_dump(exclude_none=True) == {}
+    assert plugin.border_radius is None
+    assert plugin.flat_cards is False
+
+
+@patch.dict(os.environ, {f"{CONFIG_ENV_PREFIX_PLUGINS}THEME_LIGHT__PALETTE__PRIMARY": "E133FF"})
+def test_theme_plugin_rejects_a_color_without_a_hash() -> None:
+    """A malformed color has to fail at startup, since it renders as nothing at all."""
+    with pytest.raises(ValidationError, match="String should match pattern"):
+        ThemePlugin()


### PR DESCRIPTION
## What

The theme plugin held two logo URLs. It now also carries the colours and the corner shape, so an instance can look like whoever deploys it without a fork:

```yaml
plugins:
  theme:
    border_radius: 0
    flat_cards: true
    light:
      palette:
        primary: "#E133FF"
        divider: "#E7E7EA"
    dark:
      palette:
        primary: "#00CFC6"
        divider: "#2A2A30"
        background_default: "#0C0C0E"
        background_paper: "#0C0C0E"
```

| Setting | Meaning |
| --- | --- |
| `border_radius` | How round every corner is, in pixels. `0` for square |
| `flat_cards` | Cards as a plain outline instead of a raised surface |
| `<mode>.palette.primary` | Links, buttons, anything the interface treats as actionable |
| `<mode>.palette.divider` | Borders and separators, including a card's outline |
| `<mode>.palette.background_default` | The page itself |
| `<mode>.palette.background_paper` | Surfaces on the page, such as cards |

## Nothing is branded by default

Every value is optional, and `None` means "keep the framework's own default". An unconfigured instance renders exactly as it did before this existed — there is no colour literal in application code, only in a deployment's configuration. A test asserts that specifically: with nothing configured, a card keeps MUI's own `border-radius: 4px`.

## One place translates configuration into appearance

`src/ui/helpers/Theme.ts` is the only file that maps one to the other. The setting names are MUI's own palette slots, so there is nothing to translate in between, and a value the plugin leaves unset is **omitted from the options** rather than passed as `undefined` — passing `undefined` would override MUI's default with nothing.

Supporting one more palette value is two lines: a field on `ThemePalette` and a line in `paletteFor`. That is written down in `docs/plugins/theme.rst` so the next person does not have to work it out.

## Resolved before the first paint

A palette arriving after the interface has rendered would repaint all of it, so the theme plugin is fetched in the **root route's loader**.

This costs no additional request: `MenuBar` was already fetching the same endpoint in a `useEffect` for its logo URLs. That fetch is gone, which also fixes the logo appearing a moment late — the same problem the site banner had, one level up.

## Notes for review

- Colours are validated as CSS hex. A typo would otherwise render as no colour at all, which is hard to notice; it now stops the application at startup.
- `border_radius` is `int | None` rather than defaulting to a number, because `0` is meaningful and had to stay distinguishable from "not configured".
- Shape sits beside `light`/`dark` rather than inside them, since it is not a property of a colour mode.
- Only four palette values are exposed, not all six of MUI's semantic slots. The signal colours in our styleguide would map onto `error`, `warning`, `success` and `info` — two lines each when somebody wants them, rather than four speculative fields now.

**Worth knowing before merging:** `#E133FF` on white measures **3.43 : 1**, below the 4.5 : 1 WCAG AA wants for normal text, and `primary` colours link and button text. Dark mode is fine at 10.0 : 1. Not addressed here because it is a brand decision — options are a darker `primary` with `#E133FF` kept for fills, or pointing text at MUI's derived `primary.dark`.

## Testing

- 3 Playwright specs asserting computed CSS: `#E133FF` → `rgb(225, 51, 255)` in light, `#00CFC6` → `rgb(0, 207, 198)` in dark, `border-radius: 0px` / `box-shadow: none` / `1px` border with `flat_cards`, and MUI's `4px` default when nothing is configured
- Python tests for the settings, including rejection of a colour without a `#`
- 83 python tests, 93/94 Playwright green — the one failure is `testOramaPlugin.spec.ts:54`, which also fails on `main`
- Sphinx build clean under `-W`

🤖 Generated with [Claude Code](https://claude.com/claude-code)