### PR TITLE
perf(settings): Build the settings and scan a project's versions once

### DIFF
--- a/src/vdoc/api/dependencies/auth.py
+++ b/src/vdoc/api/dependencies/auth.py
@@ -7,7 +7,7 @@ from fastapi import Depends
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 
 from vdoc.exceptions import InvalidCredentials
-from vdoc.settings import VDocSettings
+from vdoc.settings import get_settings
 
 security = HTTPBasic()
 
@@ -24,7 +24,7 @@ def require_authentication(credentials: Annotated[HTTPBasicCredentials, Depends(
     Returns:
         True if the request is authenticated.
     """
-    settings = VDocSettings()
+    settings = get_settings()
     is_correct_username = secrets.compare_digest(credentials.username.encode("utf8"), settings.api_username)
     is_correct_password = secrets.compare_digest(credentials.password.encode("utf8"), settings.api_password)
     if not (is_correct_username and is_correct_password):

--- a/src/vdoc/api/lifespan.py
+++ b/src/vdoc/api/lifespan.py
@@ -15,7 +15,7 @@ from vdoc.api.routes import projects as projects_module
 from vdoc.api.routes import version as version_module
 from vdoc.config_file import log_configuration_source
 from vdoc.methods.api.projects import get_project_version_impl
-from vdoc.settings import VDocSettings
+from vdoc.settings import get_settings
 
 _PACKAGE_PATH = Path(__file__).parent.parent
 
@@ -64,7 +64,7 @@ def _include_static_documentation_routers(fastapi: FastAPI) -> FastAPI:
         ),
         Mount(
             "/static/projects",
-            app=StaticFiles(directory=VDocSettings().docs_dir.as_posix(), html=True, check_dir=False),
+            app=StaticFiles(directory=get_settings().docs_dir.as_posix(), html=True, check_dir=False),
             name="projects",
         ),
     ]:
@@ -86,7 +86,7 @@ def _include_intersphinx_router(fastapi: FastAPI) -> FastAPI:
         """
         served_version = get_project_version_impl(name=project_name, version=version)
 
-        return FileResponse(path=VDocSettings().docs_dir / project_name / served_version / "objects.inv")
+        return FileResponse(path=get_settings().docs_dir / project_name / served_version / "objects.inv")
 
     return fastapi
 

--- a/src/vdoc/cli/main.py
+++ b/src/vdoc/cli/main.py
@@ -9,7 +9,7 @@ from rich.logging import RichHandler
 from vdoc import get_app_name, get_app_version
 from vdoc.cli.run import _cli_run
 from vdoc.constants import DEFAULT_API_PASSWORD, DEFAULT_API_USERNAME
-from vdoc.settings import VDocSettings
+from vdoc.settings import get_settings
 
 _logger = logging.getLogger(__name__)
 
@@ -51,7 +51,7 @@ def print_version(do_print: bool) -> None:  # noqa: FBT001
 
 def check_for_default_credentials() -> None:
     """Checks the configured API credentials and warns if the default credentials are used."""
-    settings = VDocSettings()
+    settings = get_settings()
     if settings.api_password == DEFAULT_API_PASSWORD and settings.api_username == DEFAULT_API_USERNAME:
         _logger.warning(
             "The application is running using the default credentials. Update them according to the documentation!"

--- a/src/vdoc/cli/run.py
+++ b/src/vdoc/cli/run.py
@@ -6,7 +6,7 @@ from typing import Annotated
 import typer
 
 from vdoc.methods.cli.cli_run_method import run_impl
-from vdoc.settings import VDocSettings
+from vdoc.settings import get_settings
 
 _logger = logging.getLogger(__name__)
 
@@ -15,11 +15,11 @@ def _cli_run(
     bind_address: Annotated[
         str,
         typer.Option(help="Application bind ip address."),
-    ] = VDocSettings().bind_address,
+    ] = get_settings().bind_address,
     bind_port: Annotated[
         int,
         typer.Option(help="Application bind port."),
-    ] = VDocSettings().bind_port,
+    ] = get_settings().bind_port,
 ) -> None:  # noqa: disable=D103
     try:
         run_impl(bind_address=bind_address, bind_port=bind_port)

--- a/src/vdoc/methods/api/project_categories.py
+++ b/src/vdoc/methods/api/project_categories.py
@@ -1,7 +1,7 @@
 """Contains all projects REST API methods."""
 
 from vdoc.models.project_category import ProjectCategory
-from vdoc.settings import VDocSettings
+from vdoc.settings import get_settings
 
 
 def list_project_categories_impl() -> list[ProjectCategory]:
@@ -10,4 +10,4 @@ def list_project_categories_impl() -> list[ProjectCategory]:
     Returns:
         A list of all projects.
     """
-    return VDocSettings().project_categories
+    return get_settings().project_categories

--- a/src/vdoc/methods/api/projects.py
+++ b/src/vdoc/methods/api/projects.py
@@ -10,8 +10,8 @@ from packaging.version import InvalidVersion as PackagingInvalidVersion
 from packaging.version import Version
 
 from vdoc.exceptions import InvalidProjectName, InvalidVersion, ProjectVersionAlreadyExists, UploadedFileInvalid
-from vdoc.models.project import Project
-from vdoc.settings import VDocSettings
+from vdoc.models.project import Project, invalidate_published_versions
+from vdoc.settings import get_settings
 
 
 def list_projects_impl() -> list[Project]:
@@ -76,7 +76,7 @@ def upload_project_version_impl(name: str, version: str, file: UploadFile) -> JS
     except PackagingInvalidVersion as error:
         raise InvalidVersion(version=version) from error
 
-    target_path = VDocSettings().docs_dir / name / version
+    target_path = get_settings().docs_dir / name / version
 
     if target_path.is_dir():
         raise ProjectVersionAlreadyExists(name=name, version=version)
@@ -97,6 +97,11 @@ def upload_project_version_impl(name: str, version: str, file: UploadFile) -> JS
     except zipfile.BadZipFile as error:
         shutil.rmtree(path=target_path, ignore_errors=True)
         raise UploadedFileInvalid(str(error)) from error
+    finally:
+        # The only thing that changes what vdoc serves while it runs, so the only place that has to drop
+        # what was derived from it. In the `finally` because a half-written upload that was cleaned up
+        # again changed the directory just as much as a successful one.
+        invalidate_published_versions()
 
     return JSONResponse(
         status_code=status.HTTP_201_CREATED, content=f"Version '{version}' of project '{name}' uploaded successfully."

--- a/src/vdoc/models/project.py
+++ b/src/vdoc/models/project.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from functools import cached_property
+from dataclasses import dataclass
+from functools import cached_property, lru_cache
 from typing import TYPE_CHECKING
 
 from packaging.version import InvalidVersion as PackagingInvalidVersion
@@ -10,10 +11,82 @@ from packaging.version import Version
 from pydantic import BaseModel, computed_field, field_validator
 
 from vdoc.exceptions import InvalidVersion, ProjectNotFound, ProjectVersionNotFound
-from vdoc.settings import VDocSettings
+from vdoc.settings import get_settings
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+@dataclass(frozen=True)
+class _PublishedVersions:
+    """What is published for one project, in each of the forms its readers ask for."""
+
+    ordered: tuple[tuple[Version, str], ...]
+    """Every version and the directory it is published under, oldest first, so the newest is last."""
+
+    public_forms: frozenset[str]
+    """The normalized form of each, to test a requested version against without walking them all."""
+
+
+def _directory_generation(path: Path) -> int:
+    """Returns a token that changes whenever an entry is added to a directory or removed from it.
+
+    Args:
+        path: The directory to read.
+
+    Returns:
+        The directory's modification time in nanoseconds.
+    """
+    return path.stat().st_mtime_ns
+
+
+@lru_cache(maxsize=64)
+def _scan_versions(project_path: Path, _generation: int) -> _PublishedVersions:
+    """Reads the versions published for a project, once per state of its directory.
+
+    Listing a project of two dozen versions costs a directory walk and a version parse per entry, and it
+    is on the path of nearly every request. The generation makes this cache self-invalidating rather than
+    something to remember to clear: the operating system bumps a directory's modification time when a
+    version is added to it, which is a cache key that has never been seen, while the entry for the
+    previous state ages out of the cache on its own.
+
+    A version directory's own contents are deliberately not part of the generation, because an upload
+    refuses to overwrite a version that already exists. What is published is only ever added to.
+
+    Args:
+        project_path: The path of the project.
+        _generation: The state of the project directory the result belongs to. Unread: it exists to be
+            part of the cache key.
+
+    Returns:
+        The published versions of the project.
+    """
+    parsed_versions = {Version(path.name): path.name for path in project_path.glob("[!.]*") if path.is_dir()}
+    ordered = tuple(sorted(parsed_versions.items()))
+
+    return _PublishedVersions(ordered=ordered, public_forms=frozenset(version.public for version, _ in ordered))
+
+
+def invalidate_published_versions() -> None:
+    """Drops what has been read about the published versions of every project.
+
+    Call this after publishing or removing a version. The scan notices a change on its own too, but only
+    as precisely as the filesystem timestamp it reads, and those are too coarse to tell two uploads that
+    land in the same millisecond apart. Whoever writes knows exactly, so whoever writes says so.
+    """
+    _scan_versions.cache_clear()
+
+
+def _published(project_path: Path) -> _PublishedVersions:
+    """Returns the versions published for a project.
+
+    Args:
+        project_path: The path of the project.
+
+    Returns:
+        The published versions of the project.
+    """
+    return _scan_versions(project_path=project_path, _generation=_directory_generation(path=project_path))
 
 
 class Project(BaseModel):
@@ -35,8 +108,7 @@ class Project(BaseModel):
         Returns:
             The validated project name.
         """
-        settings = VDocSettings()
-        project_dir = settings.docs_dir / value
+        project_dir = get_settings().docs_dir / value
         if not project_dir.is_dir():
             raise ProjectNotFound(name=value)
         return value
@@ -48,8 +120,7 @@ class Project(BaseModel):
         Returns:
             The project's base path.
         """
-        settings = VDocSettings()
-        return settings.docs_dir / self.name
+        return get_settings().docs_dir / self.name
 
     @classmethod
     def list(cls, search_path: Path | None = None) -> list[Project]:
@@ -61,7 +132,7 @@ class Project(BaseModel):
         Returns:
             A a list of all projects.
         """
-        search_path = search_path or VDocSettings().docs_dir
+        search_path = search_path or get_settings().docs_dir
         paths = search_path.glob("[!.]*")
         projects = [Project(name=path.name) for path in paths if path.is_dir()]
 
@@ -95,7 +166,7 @@ class Project(BaseModel):
             except PackagingInvalidVersion as error:
                 raise InvalidVersion(version=version) from error
             # Version("1") == Version("1.0.0") validates to True, comparing the plain public string mitigates this issue
-            if parsed_version.public not in (version.public for version in project.versions):
+            if parsed_version.public not in _published(project_path=project._base_path).public_forms:
                 raise ProjectVersionNotFound(name=name, version=parsed_version)
 
         return return_version, project._base_path / return_version  # Path existence is validated at object construction
@@ -108,8 +179,7 @@ class Project(BaseModel):
         Returns:
             str: The project display name.
         """
-        settings = VDocSettings()
-        return settings.project_display_name_mapping.get(self.name, self.name)
+        return get_settings().project_display_name_mapping.get(self.name, self.name)
 
     @computed_field  # type: ignore[prop-decorator]  # https://docs.pydantic.dev/2.0/usage/computed_fields/
     @cached_property
@@ -119,7 +189,7 @@ class Project(BaseModel):
         Returns:
             int | None: The optional project category ID.
         """
-        settings = VDocSettings()
+        settings = get_settings()
         if category_name := settings.project_category_mapping.get(self.name):
             return next(category.id for category in settings.project_categories if category.name == category_name)
         return None
@@ -134,14 +204,8 @@ class Project(BaseModel):
         Returns:
             A list of all versions of the project.
         """
-        versions = self._base_path.glob("[!.]*")  # Path existence is validated at object construction
-        parsed_versions: dict[Version, str] = {}
-        for path in versions:
-            if not path.is_dir():
-                continue
-            parsed_versions[Version(path.name)] = path.name
-
-        return dict(sorted(parsed_versions.items()))
+        # Path existence is validated at object construction
+        return dict(_published(project_path=self._base_path).ordered)
 
     @property
     def latest(self) -> str:
@@ -150,4 +214,4 @@ class Project(BaseModel):
         Returns:
             _description_
         """
-        return self.versions[max(self.versions.keys())]
+        return _published(project_path=self._base_path).ordered[-1][1]

--- a/src/vdoc/settings/__init__.py
+++ b/src/vdoc/settings/__init__.py
@@ -1,5 +1,6 @@
 """Contains the settings definition."""
 
+from functools import lru_cache
 from pathlib import Path
 from typing import Self
 
@@ -22,7 +23,8 @@ from vdoc.models.project_category import ProjectCategory
 class VDocSettings(BaseSettings):
     """The vdoc settings."""
 
-    model_config = SettingsConfigDict(env_prefix=CONFIG_ENV_PREFIX, env_parse_none_str="None")
+    # Frozen because `get_settings` hands the same instance to every caller
+    model_config = SettingsConfigDict(env_prefix=CONFIG_ENV_PREFIX, env_parse_none_str="None", frozen=True)
 
     docs_dir: Path = DEFAULT_DOCS_DIR
     api_username: bytes = DEFAULT_API_USERNAME
@@ -100,3 +102,23 @@ class VDocSettings(BaseSettings):
                 raise ValueError(msg)
 
         return self
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> VDocSettings:
+    """Returns the settings, reading the environment and the configuration file only once.
+
+    Prefer this over constructing ``VDocSettings`` directly. Building the model validates it and parses
+    the configuration file, which together cost most of a millisecond -- significant for something read
+    several times per request -- and there is nothing to re-read: vdoc is deployed as a container with a
+    fixed environment and a mounted file, so its configuration cannot change without the process being
+    replaced.
+
+    The returned instance is shared and frozen, so it is safe to hold on to but not to modify. A test
+    that changes the environment has to call ``get_settings.cache_clear()``, which the test suite does
+    around every test.
+
+    Returns:
+        The settings.
+    """
+    return VDocSettings()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ from typer.testing import CliRunner
 from tests.utils import start_vdoc_server_and_get_uri
 from vdoc.api import create_app
 from vdoc.constants import CONFIG_ENV_PREFIX, DEFAULT_API_PASSWORD, DEFAULT_API_USERNAME
+from vdoc.settings import get_settings
 
 DUMMY_VERSIONS = (
     ("0.0.1", "0.0.2", "0.1.0", "1.0.0", "1.1.0", "2.0.0"),
@@ -29,6 +30,35 @@ DUMMY_DOCS_STRUCTURE = {
     "dummy-project-02": DUMMY_VERSIONS[1],
     "dummy-project-03": DUMMY_VERSIONS[2],
 }
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_runtest_call(item: pytest.Item) -> Generator[None, object, object]:  # noqa: ARG001
+    """Rebuilds the settings around every test body.
+
+    ``get_settings`` reads the environment and the configuration file once, because a deployed vdoc
+    cannot have either changed under it. Tests do exactly that, and they do it inside the test rather
+    than before it -- with a decorator, or with ``patch.dict`` -- which is after the fixtures that build
+    the app have already read the settings once.
+
+    Clearing at this point rather than in an autouse fixture is what makes that work: fixtures are all
+    set up by now, so the next read is the one the test itself triggers, under the environment the test
+    set. Clearing again afterwards keeps the next test from inheriting it.
+
+    Args:
+        item: The test being run. Unread: this applies to all of them.
+
+    Yields:
+        To the test body.
+
+    Returns:
+        Whatever the test body returned.
+    """
+    get_settings.cache_clear()
+    try:
+        return (yield)
+    finally:
+        get_settings.cache_clear()
 
 
 @pytest.fixture(scope="session", name="resource_dir")

--- a/tests/unit/models/test_project_caching.py
+++ b/tests/unit/models/test_project_caching.py
@@ -1,0 +1,50 @@
+"""Contains all tests for how the published versions of a project are cached."""
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from vdoc.models.project import Project
+from vdoc.settings import get_settings
+
+
+def test_the_settings_are_built_once() -> None:
+    """Read several times per request, so building them per read is waste that adds up."""
+    assert get_settings() is get_settings()
+
+
+def test_a_version_added_to_a_project_is_seen(dummy_projects_dir: Path) -> None:
+    """The scan is cached, so it has to notice that a project gained a version."""
+    project = Project(name="dummy-project-01")
+    assert project.latest == "2.0.0"
+
+    (dummy_projects_dir / "dummy-project-01" / "3.0.0").mkdir()
+
+    assert Project(name="dummy-project-01").latest == "3.0.0"
+
+
+def test_a_version_removed_from_a_project_is_seen(dummy_projects_dir: Path) -> None:
+    assert Project(name="dummy-project-01").latest == "2.0.0"
+
+    (dummy_projects_dir / "dummy-project-01" / "2.0.0" / "index.html").unlink()
+    (dummy_projects_dir / "dummy-project-01" / "2.0.0").rmdir()
+
+    assert Project(name="dummy-project-01").latest == "1.1.0"
+
+
+def test_an_upload_is_visible_immediately(
+    dummy_projects_dir: Path,  # noqa: ARG001
+    authenticated_api: TestClient,
+    example_docs_zip: Path,
+) -> None:
+    """A version published while vdoc runs must not wait for a cache to notice it."""
+    assert Project(name="dummy-project-01").latest == "2.0.0"
+
+    response = authenticated_api.post(
+        "/api/projects/dummy-project-01/versions/3.0.0",
+        files={"file": ("docs.zip", example_docs_zip.read_bytes(), "application/zip")},
+    )
+    assert response.status_code == 201
+
+    assert Project(name="dummy-project-01").latest == "3.0.0"
+    assert authenticated_api.get("/api/projects/dummy-project-01/versions/latest").json() == "3.0.0"


### PR DESCRIPTION
## Why

Two answers were recomputed constantly that cannot change between two reads of the same state:

- **The settings.** Read several times per request, and every read validated the model *and* parsed the configuration file. #386 made this markedly worse — a YAML parse per read.
- **A project's published versions.** Every request resolving a version walked the project's directory and parsed a version string per entry. The software manual has 26.

Measured against a tree shaped like the live instance — 9 projects, 102 versions, configuration file present:

| | before | after | |
| --- | --- | --- | --- |
| settings | 570 µs | 18 µs | 33× |
| `Project.list()` | 4781 µs | 92 µs | 52× |
| `Project(...).versions` | 1112 µs | 14 µs | 83× |
| `Project(...).latest` | 1710 µs | 11 µs | 155× |

`Project.list()` was the worst because each of the nine `Project()` constructions read the settings again.

## How the version cache stays correct

This is the part worth reviewing. The scan is keyed on a **generation token**: the modification time of the project's directory, which the OS bumps whenever a version directory is added or removed. A new upload is therefore a cache key that has never been seen, and the entry for the previous state ages out of the LRU on its own — no invalidation to remember.

A version directory's own *contents* are deliberately not part of the token, because an upload refuses to overwrite an existing version. What is published is only ever added to.

**Uploads invalidate explicitly as well.** A filesystem timestamp is only as precise as its clock, and two uploads can land inside the same millisecond. Whoever writes knows exactly, so whoever writes says so. It sits in a `finally`, since an upload that was cleaned up again changed the directory just as much as one that succeeded.

Four tests cover exactly this: a version added, a version removed, an upload through the API being visible immediately, and the settings being one shared instance.

## Notes for review

- `VDocSettings` is now **frozen**, since one instance is shared. I checked that nothing assigns to a settings attribute.
- The scan returns two forms — ordered, and a set of normalized version strings. Resolving a requested version was walking every version to compare `.public`; that is a set membership test.
- `get_settings()` replaces `VDocSettings()` at all 14 call sites. There is deliberately not a second way to get settings.
- The suite clears the settings cache from `pytest_runtest_call`, not an autouse fixture. Tests patch the environment *inside* the test body, which is after the fixtures that build the app have already read the settings once — an autouse fixture runs too early to help.

## Testing

87 python tests (4 new), 93/94 Playwright, mypy and `npm run lint` clean. The one Playwright failure is `testOramaPlugin.spec.ts:54`, which also fails on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)