### PR TITLE
fix(api): Answer a request for something unpublished with 404

### DIFF
--- a/docs/frame_contract.md
+++ b/docs/frame_contract.md
@@ -173,6 +173,17 @@ So every page has two addresses, and mapping between them is a pure function in 
 vdoc's own parameters never appear in the readable form. They are requests to the frame, not part of
 a page's address.
 
+`latest` stands in for a version in the static form as well, so `/static/projects/proj/latest/page.html`
+redirects to whichever version is newest. A redirect rather than the file itself, because a relative
+link inside the page resolves against the address the browser ended up on, and that has to be the
+resolved version for the link to stay inside it.
+
+**A request for something unpublished is answered honestly.** vdoc serves its own application under a
+**404** when the path names no project it has, or no version it published. A reader still gets vdoc's
+not-found page; a crawler, a link checker or an agent is told the truth. Answering 200 for every path
+made the fallback route the one that never fails, which left `/robots.txt` and every typo looking like
+a published document.
+
 ## What vdoc does around the frame
 
 Descriptive, not normative -- a framework does not have to do anything for this. It is here so that

--- a/src/vdoc/api/lifespan.py
+++ b/src/vdoc/api/lifespan.py
@@ -4,17 +4,20 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import FastAPI, status
 from fastapi.routing import Mount
 from fastapi.staticfiles import StaticFiles
-from starlette.responses import FileResponse
+from starlette.responses import FileResponse, RedirectResponse
 
 from vdoc.api.routes import plugins as plugins_module
 from vdoc.api.routes import project_categories as project_categories_module
 from vdoc.api.routes import projects as projects_module
 from vdoc.api.routes import version as version_module
 from vdoc.config_file import log_configuration_source
+from vdoc.constants import LATEST_VERSION_ALIAS, STATIC_PROJECTS_PREFIX
+from vdoc.exceptions import ProjectInventoryNotFound
 from vdoc.methods.api.projects import get_project_version_impl
+from vdoc.models.project import Project
 from vdoc.settings import get_settings
 
 _PACKAGE_PATH = Path(__file__).parent.parent
@@ -22,13 +25,16 @@ _PACKAGE_PATH = Path(__file__).parent.parent
 webapp_path = _PACKAGE_PATH / "webapp"
 docs_path = _PACKAGE_PATH / "docs"
 
+_SPHINX_INVENTORY_FILE_NAME = "objects.inv"
+
 
 @asynccontextmanager
 async def routes_loader_lifespan(fastapi: FastAPI) -> AsyncGenerator[None, None]:
     """Lifespan context manager for the FastAPI app.
 
     The order for mounting the routers is important. The frontend router must be the last one to ensure that all
-    non-api or documentation requests are handled by the frontend.
+    non-api or documentation requests are handled by the frontend, and the ``latest`` redirect has to precede
+    the static mount it redirects into.
 
     Args:
         fastapi: The FastAPI app instance.
@@ -42,6 +48,7 @@ async def routes_loader_lifespan(fastapi: FastAPI) -> AsyncGenerator[None, None]
 
     fastapi = _include_static_api_routers(fastapi=fastapi)
     fastapi = _include_intersphinx_router(fastapi=fastapi)
+    fastapi = _include_static_latest_router(fastapi=fastapi)
     fastapi = _include_static_documentation_routers(fastapi=fastapi)
     fastapi = _include_frontend_router(fastapi=fastapi)
     yield
@@ -63,7 +70,7 @@ def _include_static_documentation_routers(fastapi: FastAPI) -> FastAPI:
             name="vdoc-docs",
         ),
         Mount(
-            "/static/projects",
+            STATIC_PROJECTS_PREFIX,
             app=StaticFiles(directory=get_settings().docs_dir.as_posix(), html=True, check_dir=False),
             name="projects",
         ),
@@ -73,7 +80,7 @@ def _include_static_documentation_routers(fastapi: FastAPI) -> FastAPI:
 
 
 def _include_intersphinx_router(fastapi: FastAPI) -> FastAPI:
-    @fastapi.get("/{project_name}/{version}/objects.inv")
+    @fastapi.get(f"/{{project_name}}/{{version}}/{_SPHINX_INVENTORY_FILE_NAME}")
     def serve_sphinx_objects_inventory(project_name: str, version: str) -> FileResponse:
         """Serves the objects.inv sphinx file for intersphinx mappings.
 
@@ -81,14 +88,96 @@ def _include_intersphinx_router(fastapi: FastAPI) -> FastAPI:
             project_name: The requested project name.
             version: The requested project version.
 
+        Raises:
+            ProjectInventoryNotFound: If the project version doesn't contain an objects.inv file.
+
         Returns:
             FileResponse: The objects.inv file.
         """
         served_version = get_project_version_impl(name=project_name, version=version)
+        inventory_path = get_settings().docs_dir / project_name / served_version / _SPHINX_INVENTORY_FILE_NAME
 
-        return FileResponse(path=get_settings().docs_dir / project_name / served_version / "objects.inv")
+        # Only a generator that builds on Sphinx writes one. Without this check, asking a version built by
+        # any other generator for its inventory raises out of FileResponse as a 500.
+        if not inventory_path.is_file():
+            raise ProjectInventoryNotFound(
+                name=project_name, version=served_version, inventory=_SPHINX_INVENTORY_FILE_NAME
+            )
+
+        return FileResponse(path=inventory_path)
 
     return fastapi
+
+
+def _include_static_latest_router(fastapi: FastAPI) -> FastAPI:
+    @fastapi.get(f"{STATIC_PROJECTS_PREFIX}/{{project_name}}/{LATEST_VERSION_ALIAS}/{{file_path:path}}")
+    def redirect_latest_to_published_version(project_name: str, file_path: str) -> RedirectResponse:
+        """Redirects a ``latest`` static address to the newest published version of the project.
+
+        Redirecting rather than serving the file under the ``latest`` address is what keeps relative links
+        inside the page working: the browser resolves them against the address it ended up on, which has
+        to be the resolved version for them to stay inside it.
+
+        Args:
+            project_name: The requested project name.
+            file_path: The path of the requested file within the published version.
+
+        Returns:
+            A temporary redirect to the same file under the resolved version. Temporary, because which
+            version ``latest`` names changes with every upload.
+        """
+        served_version = get_project_version_impl(name=project_name, version=LATEST_VERSION_ALIAS)
+
+        return RedirectResponse(
+            url=f"{STATIC_PROJECTS_PREFIX}/{project_name}/{served_version}/{file_path}",
+            status_code=status.HTTP_307_TEMPORARY_REDIRECT,
+        )
+
+    return fastapi
+
+
+def _resolve_webapp_asset(file_path: str) -> Path | None:
+    """Resolves a request path to a file shipped with the web UI.
+
+    Args:
+        file_path: The requested file path.
+
+    Returns:
+        The path of the asset, or None if the request does not name one inside the web UI directory.
+    """
+    webapp_root = webapp_path.resolve()
+    asset_path = (webapp_root / file_path).resolve()
+
+    # A request path is untrusted input, and ``/`` on a Path appends ``..`` segments rather than resolving
+    # them, so the joined path can leave the web UI directory. Nothing outside it is ours to serve.
+    if not asset_path.is_relative_to(webapp_root):
+        return None
+
+    return asset_path if asset_path.is_file() else None
+
+
+def _is_frontend_route(file_path: str) -> bool:
+    """Reports whether the web UI has a route for a request path.
+
+    The UI's route surface is the landing page, a project, a version of a project, and any page within
+    that version. So a path is a route exactly when the project it names exists and the version it names,
+    if any, is published.
+
+    The page itself is deliberately not checked: a single page documentation routes its pages client
+    side, so most of them have no file of their own to look for.
+
+    Args:
+        file_path: The requested file path.
+
+    Returns:
+        True if the UI can render this path, False otherwise.
+    """
+    if not (segments := [segment for segment in file_path.split("/") if segment]):
+        return True
+
+    project_name, *rest = segments
+
+    return Project.is_published(name=project_name, version=rest[0] if rest else None)
 
 
 def _include_frontend_router(fastapi: FastAPI) -> FastAPI:
@@ -96,14 +185,23 @@ def _include_frontend_router(fastapi: FastAPI) -> FastAPI:
     def serve_ui_and_assets(file_path: str) -> FileResponse:
         """Serves the web UI and the static assets (JS bundles, ...) as a last fallback for all non-matched requests.
 
+        The UI is returned for anything it has a route for, and for everything else too -- but under a
+        404, so that a reader still gets vdoc's own not-found page while a crawler, an agent or a link
+        checker is told the truth. Answering 200 for every path made this the last route that never
+        fails, which left `/robots.txt` and every typo looking like a published document.
+
         Args:
             file_path (str): The requested file path.
 
         Returns:
             FileResponse: The requested asset file if existing, otherwise the index.html.
         """
-        if (full_path := webapp_path / file_path).is_file():
-            return FileResponse(path=full_path)
-        return FileResponse(path=webapp_path / "index.html")
+        if (asset_path := _resolve_webapp_asset(file_path=file_path)) is not None:
+            return FileResponse(path=asset_path)
+
+        return FileResponse(
+            path=webapp_path / "index.html",
+            status_code=status.HTTP_200_OK if _is_frontend_route(file_path=file_path) else status.HTTP_404_NOT_FOUND,
+        )
 
     return fastapi

--- a/src/vdoc/constants.py
+++ b/src/vdoc/constants.py
@@ -15,6 +15,12 @@ CONFIG_FILE_ENV_VAR = f"{CONFIG_ENV_PREFIX}CONFIG_FILE"
 CONFIG_FILE_SECTION_VDOC = ("vdoc",)
 CONFIG_FILE_SECTION_PLUGINS = "plugins"
 
+## ADDRESSING
+
+# Where the published files are served from, and the version alias that resolves to the newest one.
+STATIC_PROJECTS_PREFIX = "/static/projects"
+LATEST_VERSION_ALIAS = "latest"
+
 DEFAULT_DOCS_DIR = Path("/srv/vdoc/docs/")
 DEFAULT_CONFIG_FILE = Path("/srv/vdoc/vdoc.yaml")
 DEFAULT_API_USERNAME = b"admin"

--- a/src/vdoc/exceptions/__init__.py
+++ b/src/vdoc/exceptions/__init__.py
@@ -53,6 +53,16 @@ class ProjectVersionNotFound(VDocException):
         )
 
 
+class ProjectInventoryNotFound(VDocException):
+    """Exception when a project version doesn't ship the requested page inventory."""
+
+    def __init__(self, name: str, version: Version | str, inventory: str) -> None:  # noqa: D107
+        super().__init__(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Version '{version}' of project '{name}' doesn't contain a '{inventory}' file.",
+        )
+
+
 class ProjectVersionAlreadyExists(VDocException):
     """Exception when a project version already exist."""
 

--- a/src/vdoc/models/project.py
+++ b/src/vdoc/models/project.py
@@ -10,6 +10,7 @@ from packaging.version import InvalidVersion as PackagingInvalidVersion
 from packaging.version import Version
 from pydantic import BaseModel, computed_field, field_validator
 
+from vdoc.constants import LATEST_VERSION_ALIAS
 from vdoc.exceptions import InvalidVersion, ProjectNotFound, ProjectVersionNotFound
 from vdoc.settings import get_settings
 
@@ -139,6 +140,39 @@ class Project(BaseModel):
         return sorted(projects, key=lambda project: project.name)
 
     @classmethod
+    def is_published(cls, name: str, version: str | None = None) -> bool:
+        """Reports whether a project, and if given a version of it, is published.
+
+        Answers what ``get_version_and_docs_path`` answers, as a bool rather than as an exception, and
+        without building a ``Project`` for it. This is asked on every request the web UI serves, where
+        validating a model per request buys nothing.
+
+        Args:
+            name: The project name.
+            version: The project version, ``latest``, or None to ask only about the project.
+
+        Returns:
+            True if it is published, False otherwise.
+        """
+        project_path = get_settings().docs_dir / name
+        if not project_path.is_dir():
+            return False
+        if version is None:
+            return True
+
+        published = _published(project_path=project_path)
+        if version == LATEST_VERSION_ALIAS:
+            return bool(published.ordered)
+
+        try:
+            parsed_version = Version(version)
+        except PackagingInvalidVersion:
+            return False
+
+        # Compared as normalized strings for the same reason as in get_version_and_docs_path
+        return parsed_version.public in published.public_forms
+
+    @classmethod
     def get_version_and_docs_path(cls, name: str, version: str) -> tuple[str, Path]:
         """Returns the validated version and the path containing the documentation.
 
@@ -157,7 +191,7 @@ class Project(BaseModel):
         project = Project(name=name)
         return_version: str
 
-        if version == "latest":
+        if version == LATEST_VERSION_ALIAS:
             return_version = project.latest
         else:
             try:

--- a/tests/unit/api/routes/test_misc_routes.py
+++ b/tests/unit/api/routes/test_misc_routes.py
@@ -21,9 +21,21 @@ def test_sphinx_inventory(dummy_projects_dir: Path, api: TestClient) -> None:
     assert response.text == "dummy objects.inv content"
 
 
-def test_sphinx_inventory_non_existing(api: TestClient) -> None:
+def test_sphinx_inventory_non_existing_project(api: TestClient) -> None:
     response = api.get("/dummy-project-01/latest/objects.inv")
     assert response.status_code == 404
+
+
+def test_sphinx_inventory_not_shipped_by_the_version(dummy_projects_dir: Path, api: TestClient) -> None:
+    """A version built by a generator other than Sphinx has no inventory, which is a 404, not a 500."""
+    assert (dummy_projects_dir / "dummy-project-01" / "2.0.0").is_dir()
+
+    response = api.get("/dummy-project-01/latest/objects.inv")
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "message": "Version '2.0.0' of project 'dummy-project-01' doesn't contain a 'objects.inv' file."
+    }
 
 
 def test_serve_frontend_assets(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, api: TestClient) -> None:
@@ -34,9 +46,71 @@ def test_serve_frontend_assets(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, 
     assert response.text == "dummy style sheet"
 
 
-def test_serve_frontend_assets_index_fallback(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, api: TestClient) -> None:
+def test_serve_frontend_assets_rejects_path_traversal(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, api: TestClient
+) -> None:
+    """A request path is untrusted input, and nothing outside the web UI directory is ours to serve."""
+    (tmp_path / "webapp").mkdir()
+    (tmp_path / "webapp" / "index.html").write_text("dummy index.html content")
+    (tmp_path / "secret.txt").write_text("not ours to serve")
+    monkeypatch.setattr("vdoc.api.lifespan.webapp_path", tmp_path / "webapp")
+
+    response = api.get("/%2e%2e%2fsecret.txt")
+
+    assert response.status_code == 404
+    assert response.text == "dummy index.html content"
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_status_code"),
+    [
+        ("/", 200),
+        ("/dummy-project-01", 200),
+        ("/dummy-project-01/1.0.0", 200),
+        ("/dummy-project-01/latest", 200),
+        # The page is not checked, because a single page documentation has no file for most of its pages
+        ("/dummy-project-01/1.0.0/any/page/it/routes/itself", 200),
+        ("/not-a-project", 404),
+        ("/not-a-project/1.0.0", 404),
+        ("/dummy-project-01/9.9.9", 404),
+        ("/dummy-project-01/not-a-version", 404),
+        ("/robots.txt", 404),
+        ("/sitemap.xml", 404),
+    ],
+)
+def test_serve_frontend_index_status_codes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    dummy_projects_dir: Path,  # noqa: ARG001
+    api: TestClient,
+    path: str,
+    expected_status_code: int,
+) -> None:
+    """The UI is always returned, but only a path the UI has a route for is returned as a success."""
     (tmp_path / "index.html").write_text("dummy index.html content")
     monkeypatch.setattr("vdoc.api.lifespan.webapp_path", tmp_path)
-    response = api.get("/style.css")
-    assert response.status_code == 200
+
+    response = api.get(path)
+
+    assert response.status_code == expected_status_code
     assert response.text == "dummy index.html content"
+
+
+def test_static_latest_redirects_to_the_published_version(dummy_projects_dir: Path, api: TestClient) -> None:  # noqa: ARG001
+    response = api.get("/static/projects/dummy-project-01/latest/index.html", follow_redirects=False)
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "/static/projects/dummy-project-01/2.0.0/index.html"
+
+
+def test_static_latest_serves_the_file_it_redirects_to(dummy_projects_dir: Path, api: TestClient) -> None:  # noqa: ARG001
+    response = api.get("/static/projects/dummy-project-01/latest/index.html")
+
+    assert response.status_code == 200
+    assert response.text == "This is 2.0.0 of dummy-project-01"
+
+
+def test_static_latest_of_an_unknown_project(api: TestClient) -> None:
+    response = api.get("/static/projects/not-a-project/latest/index.html", follow_redirects=False)
+
+    assert response.status_code == 404


### PR DESCRIPTION
## Why

The fallback route served the web UI with a **200** for every path it was given. That made it the one route that never fails, so this was the state of things:

```
GET /robots.txt              -> 200, 392 bytes of HTML
GET /sitemap.xml             -> 200, 392 bytes of HTML
GET /definitely-not-a-thing  -> 200, 392 bytes of HTML
```

A crawler concludes you published a `robots.txt` containing HTML. A link checker reports every typo as working. An agent cannot tell a missing page from a real one — which is worse than a 404, because a 404 at least carries information.

## What changes

The UI is still returned for everything, but under a **404** whenever the path names no project vdoc has, or no version it published. A reader gets vdoc's own not-found page exactly as before; everything that reads status codes is told the truth.

| | |
| --- | --- |
| `/`, `/project`, `/project/1.0.0`, `/project/latest` | 200 |
| `/project/1.0.0/any/page/it/routes/itself` | 200 |
| `/not-a-project`, `/project/9.9.9`, `/project/not-a-version` | **404** |
| `/robots.txt`, `/sitemap.xml` | **404** |

**The page within a version is deliberately not checked.** A single page documentation routes its pages client-side, so most of them have no file to look for; demanding one would 404 pages that render perfectly well.

`Project.is_published` answers that question as a bool rather than as an exception, and without building a `Project` — it is asked on every request the UI serves.

## Two things that were answering wrongly

- **`objects.inv` raised a 500** for a version built by a generator that writes none. Reproduced against the Docusaurus-themed project on the internal instance: `FileResponse` was simply handed a path that does not exist. It is a 404 now, naming which file is missing from which version.
- **The asset lookup followed `..` out of the web UI directory.** A request path is untrusted input, and `/` on a `Path` appends `..` rather than resolving it, so the joined path could leave `webapp/`. I could not get it to leak a file — something upstream normalizes the path first — but relying on that is not a posture. The resolved path is now required to stay inside the directory, and a test asserts it.

## Also

`/static/projects/<project>/latest/…` resolves, so a hand-written or documented link does not have to name a version.

It is a **redirect** rather than the file itself, and that is the interesting part: a relative link inside the page resolves against the address the browser ended up on, so serving the file under the `latest` address would make every relative link inside it point at `latest` too. Temporary rather than permanent, because which version `latest` names changes with every upload.

## Notes for review

- `_is_frontend_route` derives the UI's route surface from what the router actually has — landing page, project, version, page below it. If a route is added to the frontend, this is the one place that has to learn about it.
- The 404 still carries the UI's HTML body, so nothing about the reader's experience changes. Only the status line does.
- One existing test asserted the old behaviour (`/style.css` → 200 with `index.html`); it now asserts 404 with the same body, which is the point of the change.

## Testing

102 python tests, **100% coverage** on both changed modules, 93/94 Playwright, mypy / `npm run lint` / `codespell` clean, Sphinx clean under `-W`. The one Playwright failure is `testOramaPlugin.spec.ts:54`, which also fails on `main`.

The frame contract gained a paragraph on this, since "why a page has two addresses" is where a reader would look for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)