### PR TITLE
feat(api): Serve llms.txt and robots.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ Multi version documentation hosting.
 The vdoc instance serving the [voraus robotik GmbH](https://www.vorausrobotik.com/) software documentation is available
 at [docs.vorausrobotik.com](https://docs.vorausrobotik.com/).
 
+## AI and agent ready
+
+Documentation is read by crawlers, link checkers and coding agents as much as by people, and a
+JavaScript application tells them nothing. vdoc therefore publishes what it holds in two files such a
+client already looks for, both generated from what is actually published:
+
+|                                                            |                                                                                                                                           |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| [`/llms.txt`](https://docs.vorausrobotik.com/llms.txt)     | Every project at its newest version, linked at the address that serves real HTML, plus the machine-readable page index each version ships |
+| [`/robots.txt`](https://docs.vorausrobotik.com/robots.txt) | Allows everything, and points at the above                                                                                                |
+
+`llms.txt` follows the [llms.txt convention](https://llmstxt.org/); `robots.txt` follows the
+[Robots Exclusion Protocol (RFC 9309)](https://www.rfc-editor.org/rfc/rfc9309.html).
+
+See [Agent and crawler discovery](https://vorausrobotik.github.io/vdoc/agent_discovery.html) for how it
+works and what it contains.
+
 ## Documentation
 
 Please read the [documentation](https://vorausrobotik.github.io/vdoc/) for more a more detailed introduction.

--- a/docs/agent_discovery.rst
+++ b/docs/agent_discovery.rst
@@ -1,0 +1,102 @@
+.. _agent-discovery:
+
+Agent and crawler discovery
+###########################
+
+A reader with a browser finds their way around **vdoc**'s interface. A client that does not run
+JavaScript does not: a crawler, a link checker or an agent fetching a URL receives an almost empty HTML
+shell from every readable address, and nothing in that shell points at the address that does carry the
+page.
+
+**vdoc** therefore states the situation in two files such a client already looks for. Both are generated
+from what is actually published, so an upload is enough to appear in them and neither can drift out of
+date.
+
+What an automated client needs to know
+======================================
+
+Every page has two addresses. ``/<project>/<version>/<page>`` answers with **vdoc**'s application;
+``/static/projects/<project>/<version>/<page>`` is the page itself. :doc:`frame_contract` explains why
+that split exists and how the two map onto each other. The consequence here is one line:
+**fetch the static address.**
+
+``/llms.txt``
+=============
+
+An index following the `llms.txt convention <https://llmstxt.org/>`_: a markdown file at the site root
+that tells an automated reader what a site holds and where to fetch it.
+
+It contains, in this order:
+
+- the site's name and one-sentence summary, from the :doc:`site plugin <plugins/site>`
+- how the two addresses relate, and that ``latest`` stands in for a version
+- a link to ``/openapi.json``, for a client that would rather read JSON
+- every project, grouped by its configured category, linked at the **newest published version** by its
+  static address
+- an ``## Optional`` section listing whatever machine-readable page index each version happens to ship
+
+The page indexes are the part worth knowing about. Rather than crawling a version page by page, a client
+can read the index the generator already wrote:
+
+.. list-table::
+   :header-rows: 1
+
+   * - File
+     - Written by
+     - Contains
+   * - ``objects.inv``
+     - Sphinx
+     - Every page and cross-reference target, zlib-compressed
+   * - ``sitemap.xml``
+     - Docusaurus
+     - Every page URL
+   * - ``search-index.json``
+     - Docusaurus
+     - The title and URL of every page, plus its text
+
+**vdoc** advertises the ones a published version actually contains, so a project is described by what it
+has rather than by which generator built it. Sphinx's ``searchindex.js`` is deliberately left out: it
+says nothing ``objects.inv`` does not already say, and listing both doubled the section for no gain.
+
+``/robots.txt``
+===============
+
+A `Robots Exclusion Protocol <https://www.rfc-editor.org/rfc/rfc9309.html>`_ file. Nothing is
+disallowed -- every published page is meant to be read -- and its real purpose here is to point at
+``/llms.txt``, which no crawler would otherwise know to look for.
+
+Configuring what they say
+=========================
+
+Neither file has settings of its own. The name and the summary come from the
+:doc:`site plugin <plugins/site>`, the grouping from ``project_categories`` and
+``project_category_mapping`` in the :ref:`configuration <configuration-file>`, and everything else from
+the documentation directory.
+
+.. code-block:: yaml
+
+   plugins:
+     site:
+       title: Example Software Documentation
+       description: Documentation for the Example automation platform.
+
+That title becomes the heading of ``llms.txt``, and the description its summary. Without them the file
+still renders, under a generic heading.
+
+Absolute URLs and reverse proxies
+=================================
+
+Both files list absolute URLs, so that they keep working once copied away from the site they came from.
+The host is taken from the request, honoring ``X-Forwarded-Proto`` and ``X-Forwarded-Host`` so that a
+**vdoc** behind a reverse proxy names the address readers actually use rather than its own container.
+
+Trying it
+=========
+
+.. code-block:: sh
+
+   curl https://your-vdoc.example.com/llms.txt
+   curl https://your-vdoc.example.com/robots.txt
+
+A useful check, if something looks wrong: every link in ``llms.txt`` should answer ``200``. A readable
+address that answers ``404`` means the version is gone; a static address that does means the file is.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ vdoc
 getting_started
 configuration
 plugins
+agent_discovery
 frame_contract
 development
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "uvicorn",
     "pydantic~=2.0",
     "pydantic-settings[yaml]~=2.0",
+    "jinja2~=3.0",
 ]
 
 # Add CLI entry points here
@@ -65,6 +66,7 @@ vdoc = "vdoc.cli.main:app"
 "vdoc" = [
     "docs/**",
     "webapp/**",
+    "templates/*.j2",
 ]
 
 [dependency-groups]

--- a/src/vdoc/api/lifespan.py
+++ b/src/vdoc/api/lifespan.py
@@ -9,6 +9,7 @@ from fastapi.routing import Mount
 from fastapi.staticfiles import StaticFiles
 from starlette.responses import FileResponse, RedirectResponse
 
+from vdoc.api.routes import agent_discovery as agent_discovery_module
 from vdoc.api.routes import plugins as plugins_module
 from vdoc.api.routes import project_categories as project_categories_module
 from vdoc.api.routes import projects as projects_module
@@ -47,6 +48,7 @@ async def routes_loader_lifespan(fastapi: FastAPI) -> AsyncGenerator[None, None]
     log_configuration_source()
 
     fastapi = _include_static_api_routers(fastapi=fastapi)
+    fastapi = _include_agent_discovery_router(fastapi=fastapi)
     fastapi = _include_intersphinx_router(fastapi=fastapi)
     fastapi = _include_static_latest_router(fastapi=fastapi)
     fastapi = _include_static_documentation_routers(fastapi=fastapi)
@@ -59,6 +61,11 @@ def _include_static_api_routers(fastapi: FastAPI) -> FastAPI:
     fastapi.include_router(project_categories_module.router, prefix="/api")
     fastapi.include_router(version_module.router, prefix="/api")
     fastapi.include_router(plugins_module.get_router(), prefix="/api")
+    return fastapi
+
+
+def _include_agent_discovery_router(fastapi: FastAPI) -> FastAPI:
+    fastapi.include_router(agent_discovery_module.router)
     return fastapi
 
 

--- a/src/vdoc/api/routes/agent_discovery.py
+++ b/src/vdoc/api/routes/agent_discovery.py
@@ -1,0 +1,35 @@
+"""Contains the routes an automated reader looks for."""
+
+from fastapi import APIRouter
+from fastapi.responses import PlainTextResponse
+from starlette.requests import Request
+
+from vdoc.methods.api.agent_discovery import get_public_base_url, render_llms_txt_impl, render_robots_txt_impl
+
+router = APIRouter(tags=["Agent discovery"])
+
+
+@router.get("/llms.txt", response_class=PlainTextResponse)
+def get_llms_txt(request: Request) -> PlainTextResponse:
+    """Serves the ``llms.txt`` index of everything currently published.
+
+    Args:
+        request: The incoming request, which is what knows the public base URL to link to.
+
+    Returns:
+        The rendered ``llms.txt``.
+    """
+    return PlainTextResponse(content=render_llms_txt_impl(base_url=get_public_base_url(request=request)))
+
+
+@router.get("/robots.txt", response_class=PlainTextResponse)
+def get_robots_txt(request: Request) -> PlainTextResponse:
+    """Serves ``robots.txt``, which points at ``llms.txt``.
+
+    Args:
+        request: The incoming request, which is what knows the public base URL to link to.
+
+    Returns:
+        The rendered ``robots.txt``.
+    """
+    return PlainTextResponse(content=render_robots_txt_impl(base_url=get_public_base_url(request=request)))

--- a/src/vdoc/constants.py
+++ b/src/vdoc/constants.py
@@ -21,6 +21,24 @@ CONFIG_FILE_SECTION_PLUGINS = "plugins"
 STATIC_PROJECTS_PREFIX = "/static/projects"
 LATEST_VERSION_ALIAS = "latest"
 
+## AGENT DISCOVERY
+
+# The heading of llms.txt when the site plugin does not name the instance.
+DEFAULT_SITE_TITLE = "Documentation"
+
+# Files a documentation generator may ship that index its pages for a machine reader. vdoc advertises
+# the ones a published version actually contains, so a project is described by what it has rather than
+# by which generator built it. Sphinx writes the first, Docusaurus the other two.
+#
+# Deliberately not listed: Sphinx's `searchindex.js`. It says nothing `objects.inv` does not already say
+# for the same version, and listing both put two lines per Sphinx project in a file whose whole value is
+# being short enough to read in one go.
+PAGE_INVENTORY_FILES = {
+    "objects.inv": "Sphinx inventory of every page and cross-reference target (zlib-compressed)",
+    "sitemap.xml": "XML sitemap of every page URL",
+    "search-index.json": "full-text search index with the title and URL of every page",
+}
+
 DEFAULT_DOCS_DIR = Path("/srv/vdoc/docs/")
 DEFAULT_CONFIG_FILE = Path("/srv/vdoc/vdoc.yaml")
 DEFAULT_API_USERNAME = b"admin"

--- a/src/vdoc/methods/api/agent_discovery.py
+++ b/src/vdoc/methods/api/agent_discovery.py
@@ -1,0 +1,145 @@
+"""Contains the documents that tell an automated reader what this instance holds.
+
+``/llms.txt`` follows https://llmstxt.org and ``/robots.txt`` follows RFC 9309. Both are rendered from
+templates in ``vdoc/templates`` and derived from what is actually published, so an upload is enough to
+appear in them. The "Agent and crawler discovery" page of the documentation says what they contain.
+"""
+
+from jinja2 import Environment, PackageLoader, select_autoescape
+from starlette.requests import Request
+
+from vdoc.constants import (
+    DEFAULT_SITE_TITLE,
+    LATEST_VERSION_ALIAS,
+    PAGE_INVENTORY_FILES,
+    STATIC_PROJECTS_PREFIX,
+)
+from vdoc.models.plugins.site import SitePlugin
+from vdoc.models.project import Project
+from vdoc.settings import get_settings
+
+_UNCATEGORIZED_SECTION_TITLE = "Projects"
+
+# Both documents are plain text, so the templates decide the whitespace: block tags are trimmed and the
+# trailing newline is kept. Autoescaping stays off for text and on for the markup extensions, so that a
+# template added later cannot quietly interpolate unescaped HTML.
+_templates = Environment(
+    loader=PackageLoader("vdoc", "templates"),
+    autoescape=select_autoescape(enabled_extensions=("html", "xml"), default=False),
+    trim_blocks=True,
+    lstrip_blocks=True,
+    keep_trailing_newline=True,
+)
+
+
+def get_public_base_url(request: Request) -> str:
+    """Returns the absolute base URL this vdoc instance is reached under, without a trailing slash.
+
+    Both documents list absolute URLs, so that they keep working once copied away from the site they were
+    fetched from. Only the request knows which host that is, and behind a reverse proxy only its
+    forwarded headers do.
+
+    Those headers are attacker-controlled, which is harmless here: they are used for nothing but
+    composing self-references into the very response the sender receives, so a forged host misleads no
+    one but its sender.
+
+    Args:
+        request: The incoming request.
+
+    Returns:
+        The base URL of this instance.
+    """
+    forwarded_proto = request.headers.get("x-forwarded-proto")
+    forwarded_host = request.headers.get("x-forwarded-host")
+    scheme = forwarded_proto.split(",")[0].strip() if forwarded_proto else request.url.scheme
+    host = forwarded_host.split(",")[0].strip() if forwarded_host else request.url.netloc
+
+    return f"{scheme}://{host}"
+
+
+def _sections(projects: list[Project]) -> list[tuple[str, list[Project]]]:
+    """Groups projects into their configured categories, in the order the categories are configured.
+
+    Projects without a category are collected into a trailing section, so that a partially categorized
+    instance still lists all of them.
+
+    Args:
+        projects: The projects to group.
+
+    Returns:
+        The title of each section and the projects in it, skipping the sections no project belongs to.
+    """
+
+    def members(category_id: int | None) -> list[Project]:
+        # By display name, because that is the name the reader sees in the list
+        return sorted(
+            (project for project in projects if project.category_id == category_id),
+            key=lambda project: project.display_name,
+        )
+
+    categories = sorted(get_settings().project_categories, key=lambda category: category.id)
+    sections = [(category.name, members(category_id=category.id)) for category in categories]
+    sections.append((_UNCATEGORIZED_SECTION_TITLE, members(category_id=None)))
+
+    return [(title, section_projects) for title, section_projects in sections if section_projects]
+
+
+def _inventories(projects: list[Project]) -> list[tuple[Project, str, str]]:
+    """Collects the page inventories the newest version of each project actually ships.
+
+    Args:
+        projects: The projects to look at.
+
+    Returns:
+        The project, file name and description of every inventory file present.
+    """
+    docs_dir = get_settings().docs_dir
+
+    return [
+        (project, file_name, description)
+        for project in projects
+        for file_name, description in PAGE_INVENTORY_FILES.items()
+        if (docs_dir / project.name / project.latest / file_name).is_file()
+    ]
+
+
+def render_llms_txt_impl(base_url: str) -> str:
+    """Renders the ``llms.txt`` index of everything currently published.
+
+    Args:
+        base_url: The absolute base URL of this vdoc instance, without a trailing slash.
+
+    Returns:
+        The rendered ``llms.txt`` as markdown.
+    """
+    site = SitePlugin()
+
+    # A project directory without a parsable version in it has nothing to link to, and asking it for its
+    # latest version would raise. Leaving it out keeps one broken upload from taking the index down.
+    projects = [project for project in Project.list() if project.versions]
+
+    return _templates.get_template("llms.txt.j2").render(
+        title=site.title or DEFAULT_SITE_TITLE,
+        description=site.description,
+        long_description=site.long_description or (),
+        sections=_sections(projects=projects),
+        inventories=_inventories(projects=projects),
+        base_url=base_url,
+        static_prefix=STATIC_PROJECTS_PREFIX,
+        latest_alias=LATEST_VERSION_ALIAS,
+    )
+
+
+def render_robots_txt_impl(base_url: str) -> str:
+    """Renders ``robots.txt``.
+
+    Args:
+        base_url: The absolute base URL of this vdoc instance, without a trailing slash.
+
+    Returns:
+        The rendered ``robots.txt``.
+    """
+    return _templates.get_template("robots.txt.j2").render(
+        base_url=base_url,
+        static_prefix=STATIC_PROJECTS_PREFIX,
+    )

--- a/src/vdoc/templates/llms.txt.j2
+++ b/src/vdoc/templates/llms.txt.j2
@@ -1,0 +1,55 @@
+{#-
+  The index an automated reader is pointed at, following https://llmstxt.org.
+
+  This repeats what the documentation says about the two addresses, on purpose: a client fetching this
+  file has only this file. It will not go and read the documentation, so the explanation has to travel
+  with the answer.
+
+  Rendered as plain text, so whitespace here is the whitespace in the answer. The environment trims
+  block tags, which is why the blank lines that matter are written out literally.
+-#}
+{%- macro static(project, file_name) -%}
+{{ base_url }}{{ static_prefix }}/{{ project.name }}/{{ project.latest }}/{{ file_name }}
+{%- endmacro -%}
+# {{ title }}
+
+{% if description %}
+> {{ description }}
+
+{% endif %}
+{% if long_description %}
+{% for line in long_description %}
+{{ line }}
+{% endfor %}
+
+{% endif %}
+Every page has two addresses. The readable one, `/<project>/<version>/<page>`, is a JavaScript
+application that renders the page inside a frame, so a plain HTTP fetch of it returns an empty shell.
+The static one, `{{ static_prefix }}/<project>/<version>/<page>`, is the page itself as server-rendered
+HTML. Fetch the static address.
+
+`{{ latest_alias }}` stands in for a version and resolves to the newest published one, so
+`{{ static_prefix }}/<project>/{{ latest_alias }}/index.html` stays correct as versions are added. The
+links below name a resolved version instead, because that is what is newest right now.
+
+The REST API described by `{{ base_url }}/openapi.json` lists projects, versions and categories as JSON.
+
+{% for title, projects in sections %}
+## {{ title }}
+
+{% for project in projects %}
+{% set count = project.versions | length %}
+- [{{ project.display_name }} {{ project.latest }}]({{ static(project, "index.html") }}): {% if count == 1 %}the only published version{% else %}the newest of {{ count }} published versions{% endif %}
+
+{% endfor %}
+
+{% endfor %}
+{% if inventories %}
+## Optional
+
+Machine-readable page indexes, for enumerating the pages of a version without crawling it:
+
+{% for project, file_name, description in inventories %}
+- [{{ project.display_name }} {{ project.latest }} {{ file_name }}]({{ static(project, file_name) }}): {{ description }}
+{% endfor %}
+{% endif %}

--- a/src/vdoc/templates/robots.txt.j2
+++ b/src/vdoc/templates/robots.txt.j2
@@ -1,0 +1,14 @@
+{#-
+  Nothing is disallowed: every published page is meant to be read. What this file is really for here is
+  the pointer to llms.txt, which no crawler would otherwise know to look for. Format per RFC 9309.
+-#}
+# Documentation served by vdoc: https://github.com/vorausrobotik/vdoc
+#
+# An index written for automated readers, following https://llmstxt.org, is at:
+#   {{ base_url }}/llms.txt
+#
+# It explains that every page has two addresses, and that the one to fetch is
+#   {{ base_url }}{{ static_prefix }}/<project>/<version>/<page>
+
+User-agent: *
+Allow: /

--- a/tests/unit/api/routes/test_agent_discovery.py
+++ b/tests/unit/api/routes/test_agent_discovery.py
@@ -1,0 +1,162 @@
+"""Contains all unit tests for the documents written for automated readers."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from vdoc.constants import CONFIG_ENV_PREFIX_PLUGINS
+
+
+def test_llms_txt_is_served_as_plain_text(dummy_projects_dir: Path, api: TestClient) -> None:  # noqa: ARG001
+    response = api.get("/llms.txt")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/plain")
+
+
+def test_llms_txt_lists_the_newest_version_of_every_project(dummy_projects_dir: Path, api: TestClient) -> None:  # noqa: ARG001
+    body = api.get("/llms.txt").text
+
+    assert "- [dummy-project-01 2.0.0](http://testserver/static/projects/dummy-project-01/2.0.0/index.html)" in body
+    assert "- [dummy-project-02 6.0](http://testserver/static/projects/dummy-project-02/6.0/index.html)" in body
+    # Superseded versions are deliberately not listed, the versions API enumerates them
+    assert "1.0.0/index.html" not in body
+    assert "the newest of 6 published versions" in body
+
+
+def test_llms_txt_explains_both_addresses(dummy_projects_dir: Path, api: TestClient) -> None:  # noqa: ARG001
+    body = api.get("/llms.txt").text
+
+    assert "/static/projects/<project>/<version>/<page>" in body
+    assert "/static/projects/<project>/latest/index.html" in body
+    assert "http://testserver/openapi.json" in body
+
+
+def test_llms_txt_falls_back_to_a_generic_heading(dummy_projects_dir: Path, api: TestClient) -> None:  # noqa: ARG001
+    """An instance that has not named itself still needs a heading."""
+    assert api.get("/llms.txt").text.startswith("# Documentation\n")
+
+
+def test_llms_txt_uses_the_site_plugin(dummy_projects_dir: Path, request: pytest.FixtureRequest) -> None:  # noqa: ARG001
+    environment = {
+        f"{CONFIG_ENV_PREFIX_PLUGINS}SITE_TITLE": "Example Documentation",
+        f"{CONFIG_ENV_PREFIX_PLUGINS}SITE_DESCRIPTION": "Everything about the platform.",
+        f"{CONFIG_ENV_PREFIX_PLUGINS}SITE_LONG_DESCRIPTION": '["- **example.core**", "- **example.pioneer**"]',
+    }
+    with patch.dict(os.environ, environment):
+        # The plugin reads its configuration when the app is created, so the app comes after the patch
+        api: TestClient = request.getfixturevalue("api")
+        body = api.get("/llms.txt").text
+
+    assert body.startswith("# Example Documentation\n\n> Everything about the platform.\n")
+    assert "- **example.core**\n- **example.pioneer**" in body
+
+
+def test_llms_txt_uses_the_forwarded_host_and_scheme(dummy_projects_dir: Path, api: TestClient) -> None:  # noqa: ARG001
+    body = api.get("/llms.txt", headers={"x-forwarded-proto": "https", "x-forwarded-host": "docs.example.com"}).text
+
+    assert "https://docs.example.com/static/projects/dummy-project-01/2.0.0/index.html" in body
+    assert "testserver" not in body
+
+
+def test_llms_txt_advertises_only_the_inventories_that_exist(dummy_projects_dir: Path, api: TestClient) -> None:
+    (dummy_projects_dir / "dummy-project-01" / "2.0.0" / "objects.inv").write_text("dummy inventory")
+    (dummy_projects_dir / "dummy-project-02" / "6.0" / "sitemap.xml").write_text("<urlset/>")
+
+    body = api.get("/llms.txt").text
+
+    assert "## Optional" in body
+    assert "http://testserver/static/projects/dummy-project-01/2.0.0/objects.inv" in body
+    assert "http://testserver/static/projects/dummy-project-02/6.0/sitemap.xml" in body
+    assert "dummy-project-03" not in body.split("## Optional")[1]
+
+
+def test_llms_txt_without_any_inventory_has_no_optional_section(dummy_projects_dir: Path, api: TestClient) -> None:  # noqa: ARG001
+    assert "## Optional" not in api.get("/llms.txt").text
+
+
+def test_llms_txt_groups_projects_into_configured_categories(
+    dummy_projects_dir: Path, request: pytest.FixtureRequest
+) -> None:
+    environment = {
+        "VDOC_DOCS_DIR": str(dummy_projects_dir),
+        "VDOC_PROJECT_CATEGORIES": '[{"id": 1, "name": "Components"}, {"id": 0, "name": "General"}]',
+        "VDOC_PROJECT_CATEGORY_MAPPING": '{"dummy-project-01": "General"}',
+    }
+    with patch.dict(os.environ, environment):
+        api: TestClient = request.getfixturevalue("api")
+        body = api.get("/llms.txt").text
+
+    # The categorized project gets its own section, and the uncategorized rest trails it
+    assert "## Components" not in body, "A category without projects gets no empty section"
+    assert body.index("## General") < body.index("dummy-project-01") < body.index("## Projects")
+
+
+def test_llms_txt_skips_projects_without_a_version(dummy_projects_dir: Path, api: TestClient) -> None:
+    """One unusable project directory must not take the whole index down."""
+    (dummy_projects_dir / "empty-project").mkdir()
+
+    body = api.get("/llms.txt").text
+
+    assert "empty-project" not in body
+    assert "dummy-project-01" in body
+
+
+def test_llms_txt_on_an_empty_instance(tmp_path: Path, request: pytest.FixtureRequest) -> None:
+    with patch.dict(os.environ, {"VDOC_DOCS_DIR": str(tmp_path)}, clear=True):
+        api: TestClient = request.getfixturevalue("api")
+        response = api.get("/llms.txt")
+
+    assert response.status_code == 200
+    assert response.text.startswith("# Documentation\n")
+    assert "## " not in response.text
+
+
+def test_llms_txt_follows_an_upload(
+    dummy_projects_dir: Path,  # noqa: ARG001
+    authenticated_api: TestClient,
+    example_docs_zip: Path,
+) -> None:
+    """A version published while vdoc runs has to show up, so nothing about it may be cached for long."""
+    assert "3.0.0" not in authenticated_api.get("/llms.txt").text
+
+    response = authenticated_api.post(
+        "/api/projects/dummy-project-01/versions/3.0.0",
+        files={"file": ("docs.zip", example_docs_zip.read_bytes(), "application/zip")},
+    )
+    assert response.status_code == 201
+
+    body = authenticated_api.get("/llms.txt").text
+    assert "http://testserver/static/projects/dummy-project-01/3.0.0/index.html" in body
+    assert "the newest of 7 published versions" in body
+
+
+def test_robots_txt_allows_everything_and_points_at_llms_txt(api: TestClient) -> None:
+    response = api.get("/robots.txt")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/plain")
+    assert "User-agent: *" in response.text
+    assert "Allow: /" in response.text
+    assert "http://testserver/llms.txt" in response.text
+    assert "Disallow" not in response.text
+
+
+def test_robots_txt_uses_the_forwarded_host(api: TestClient) -> None:
+    body = api.get("/robots.txt", headers={"x-forwarded-proto": "https", "x-forwarded-host": "docs.example.com"}).text
+
+    assert "https://docs.example.com/llms.txt" in body
+    assert "testserver" not in body
+
+
+def test_llms_txt_before_the_docs_directory_exists(tmp_path: Path, request: pytest.FixtureRequest) -> None:
+    """A deployment whose documentation volume has not been populated yet is empty, not broken."""
+    with patch.dict(os.environ, {"VDOC_DOCS_DIR": str(tmp_path / "never-created")}, clear=True):
+        api: TestClient = request.getfixturevalue("api")
+        response = api.get("/llms.txt")
+
+    assert response.status_code == 200
+    assert response.text.startswith("# Documentation\n")

--- a/tests/unit/api/routes/test_misc_routes.py
+++ b/tests/unit/api/routes/test_misc_routes.py
@@ -74,7 +74,7 @@ def test_serve_frontend_assets_rejects_path_traversal(
         ("/not-a-project/1.0.0", 404),
         ("/dummy-project-01/9.9.9", 404),
         ("/dummy-project-01/not-a-version", 404),
-        ("/robots.txt", 404),
+        # `/robots.txt` and `/llms.txt` are served for real, see test_agent_discovery.py
         ("/sitemap.xml", 404),
     ],
 )

--- a/uv.lock
+++ b/uv.lock
@@ -2226,6 +2226,7 @@ source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
     { name = "importlib-metadata" },
+    { name = "jinja2" },
     { name = "packaging" },
     { name = "pydantic" },
     { name = "pydantic-settings", extra = ["yaml"] },
@@ -2370,6 +2371,7 @@ tox = [
 requires-dist = [
     { name = "fastapi" },
     { name = "importlib-metadata" },
+    { name = "jinja2", specifier = "~=3.0" },
     { name = "packaging" },
     { name = "pydantic", specifier = "~=2.0" },
     { name = "pydantic-settings", extras = ["yaml"], specifier = "~=2.0" },


### PR DESCRIPTION
## Why

A reader with a browser finds their way around vdoc's interface. A client that does not run JavaScript does not — a crawler, a link checker or an agent fetching a URL gets an almost empty shell from every readable address, and nothing in that shell points at the address that *does* carry the page.

Concretely, before this: fetching `https://docs.vorausrobotik.com/` returned 392 bytes containing the word `vdoc`. Working out that the content lives under `/static/projects/…` required reading the bundled JavaScript.

## What is served

**`/llms.txt`** — an index following [llmstxt.org](https://llmstxt.org/):

```
# SOFTWARE DOCUMENTATION

> Documentation for voraus — the industrial automation software platform.

...

Every page has two addresses. The readable one, `/<project>/<version>/<page>`, is a JavaScript
application that renders the page inside a frame, so a plain HTTP fetch of it returns an empty shell.
The static one, `/static/projects/<project>/<version>/<page>`, is the page itself as server-rendered
HTML. Fetch the static address.

## General

- [Software Manual 2.0.1](https://…/static/projects/voraus-software-manual/2.0.1/index.html): the newest of 18 published versions
```

**`/robots.txt`** — per [RFC 9309](https://www.rfc-editor.org/rfc/rfc9309.html). Nothing disallowed, since every published page is meant to be read. Its real purpose here is pointing at `llms.txt`, which no crawler would otherwise know to look for.

## The page indexes

The part worth knowing about. Rather than crawling a version page by page, a client can read the index the generator already wrote:

| File | Written by | Contains |
| --- | --- | --- |
| `objects.inv` | Sphinx | Every page and cross-reference target |
| `sitemap.xml` | Docusaurus | Every page URL |
| `search-index.json` | Docusaurus | Title, URL and text of every page |

vdoc advertises the ones a published version **actually contains**, so a project is described by what it has rather than by which generator built it. Sphinx's `searchindex.js` is deliberately left out: it says nothing `objects.inv` does not already say, and listing both doubled the section for no gain.

## Notes for review

**Rendered from Jinja templates** in `src/vdoc/templates`, because both files are mostly prose and prose does not belong in a string literal. The templates also do the formatting — they receive the projects and compose the links themselves, so Python is left with three jobs: resolve the base URL, group the projects, find the inventory files that exist. Registered as package data; I built the wheel and confirmed they ship in it.

**Deliberately not cached.** Building the index costs ~1.7 ms; a local cache cut that to 117 µs. But that cache needed a generation token, three frozen dataclasses and an invalidation call in the upload path — roughly a hundred lines and a stale-index risk, to save 1.6 ms on an endpoint a crawler reads a few times a day. #389 dealt with the hot paths; this is not one of them. I measured both before deciding, and the reasoning is in the commit message so nobody re-adds it on reflex.

**No settings of its own.** The name and summary come from the site plugin, the grouping from `project_categories`, everything else from the documentation directory. An upload is enough to appear, and neither file can drift out of date.

**`X-Forwarded-Proto`/`Host` are honoured** so a vdoc behind a proxy names the address readers use. Those headers are attacker-controlled, which is harmless — they only compose self-references into the response the sender receives.

**On the repetition.** The two-addresses explanation appears in the template *and* in the frame contract. That is intentional in the template: a client fetching `llms.txt` has only that file and will not go read the docs, so the explanation has to travel with the answer. There is a comment saying so, to stop someone deduplicating it later. The new documentation page, by contrast, states only the consequence and links to the frame contract for the mechanism — no third copy.

One case in `test_misc_routes.py` changed: `/robots.txt` was asserted to be a 404 after #390, and is now a real document.

## Documentation

- New page: **Agent and crawler discovery**, in the toctree — both files, what a client needs to know, the page indexes, configuration and the reverse-proxy behaviour.
- **README** gains an *AI and agent ready* section linking both live files, [llmstxt.org](https://llmstxt.org/), [RFC 9309](https://www.rfc-editor.org/rfc/rfc9309.html) and the new page.

## Testing

116 python tests (15 new), **100% coverage** on both new modules, Sphinx clean under `-W` with every cross-reference checked in the built HTML, `mypy` / `npm run lint` / `codespell` clean.

Two things verified beyond the suite:

- Against the real documentation directory, **every link in the generated `llms.txt` answers 200** — all 21, plus `/openapi.json`.
- The template refactor is output-preserving: both revisions rendered against the same fixture are **byte-identical**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)