### PR TITLE
feat(api): Serve a sitemap and advertise every page's static address

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,22 @@ at [docs.vorausrobotik.com](https://docs.vorausrobotik.com/).
 ## AI and agent ready
 
 Documentation is read by crawlers, link checkers and coding agents as much as by people, and a
-JavaScript application tells them nothing. vdoc therefore publishes what it holds in two files such a
-client already looks for, both generated from what is actually published:
+JavaScript application tells them nothing. vdoc therefore publishes what it holds in three files such a
+client already looks for, all generated from what is actually published:
 
-|                                                            |                                                                                                                                           |
-| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| [`/llms.txt`](https://docs.vorausrobotik.com/llms.txt)     | Every project at its newest version, linked at the address that serves real HTML, plus the machine-readable page index each version ships |
-| [`/robots.txt`](https://docs.vorausrobotik.com/robots.txt) | Allows everything, and points at the above                                                                                                |
+|                                                              |                                                                                                                                           |
+| ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| [`/llms.txt`](https://docs.vorausrobotik.com/llms.txt)       | Every project at its newest version, linked at the address that serves real HTML, plus the machine-readable page index each version ships |
+| [`/sitemap.xml`](https://docs.vorausrobotik.com/sitemap.xml) | The same entry points as a sitemap, dated by when each version was published                                                              |
+| [`/robots.txt`](https://docs.vorausrobotik.com/robots.txt)   | Allows everything, and points at both of the above                                                                                        |
 
-`llms.txt` follows the [llms.txt convention](https://llmstxt.org/); `robots.txt` follows the
+`llms.txt` follows the [llms.txt convention](https://llmstxt.org/), `sitemap.xml` the
+[sitemaps protocol](https://www.sitemaps.org/protocol.html), and `robots.txt` the
 [Robots Exclusion Protocol (RFC 9309)](https://www.rfc-editor.org/rfc/rfc9309.html).
+
+A page requested at its readable address answers with a `Link` header naming the static address that
+carries it, so a client that started from a link a person shared finds the content from the response
+it already has. And an agent is told which of the two addresses to quote back: the readable one.
 
 See [Agent and crawler discovery](https://vorausrobotik.github.io/vdoc/agent-discovery) for how it
 works and what it contains.

--- a/docs/docs/05-agent-discovery.md
+++ b/docs/docs/05-agent-discovery.md
@@ -5,16 +5,34 @@ JavaScript does not: a crawler, a link checker or an agent fetching a URL receiv
 shell from every readable address, and nothing in that shell points at the address that does carry the
 page.
 
-**vdoc** therefore states the situation in two files such a client already looks for. Both are generated
-from what is actually published, so an upload is enough to appear in them and neither can drift out of
-date.
+**vdoc** therefore states the situation in three files such a client already looks for, and in the shell
+itself. All three are generated from what is actually published, so an upload is enough to appear in
+them and none of them can drift out of date.
 
 ## What an automated client needs to know
 
 Every page has two addresses. `/<project>/<version>/<page>` answers with **vdoc**'s application;
 `/static/projects/<project>/<version>/<page>` is the page itself. [The frame contract](06-frame-contract.md)
-explains why that split exists and how the two map onto each other. The consequence here is one line:
-**fetch the static address.**
+explains why that split exists and how the two map onto each other. The consequence here is two lines:
+
+- **Fetch the static address.** It is the only one that carries the page without a browser.
+- **Pass on the readable one.** The two differ by nothing but the prefix, and a person following a link
+  wants the page inside **vdoc**'s interface, with its navigation, version picker and search.
+
+The second line is what keeps an agent's answer citable: a reader clicking a quoted link gets the page
+in the site, not a bare file outside it.
+
+## What a client reaching the readable address gets
+
+A client handed a link by a person starts at the readable address, not at `robots.txt`. The shell it
+receives there says where the page itself is, twice over:
+
+- a `Link` header naming the static address of that same page, as
+  `</static/projects/…>; rel="alternate"; type="text/html"`
+- a `<noscript>` block stating the prefix rule and pointing at `/llms.txt`
+
+The shell still has no content in it. Both exist so that a client holding the wrong address of the
+right page can find the right one in the response it already has.
 
 ## `/llms.txt`
 
@@ -24,11 +42,12 @@ that tells an automated reader what a site holds and where to fetch it.
 It contains, in this order:
 
 - the site's name and one-sentence summary, from the [site plugin](04-plugins/02-site.md)
-- how the two addresses relate, and that `latest` stands in for a version
+- how the two addresses relate, which one to fetch, which one to quote, and that `latest` stands in for
+  a version
 - a link to `/openapi.json`, for a client that would rather read JSON
 - every project, grouped by its configured category, linked at the **newest published version** by its
   static address
-- an `## Optional` section listing whatever machine-readable page index each version happens to ship
+- a `## Page indexes` section listing whatever machine-readable page index each version happens to ship
 
 The page indexes are the part worth knowing about. Rather than crawling a version page by page, a client
 can read the index the generator already wrote:
@@ -46,12 +65,35 @@ says nothing `objects.inv` does not already say, and listing both doubled the se
 ## `/robots.txt`
 
 A [Robots Exclusion Protocol](https://www.rfc-editor.org/rfc/rfc9309.html) file. Nothing is
-disallowed — every published page is meant to be read — and its real purpose here is to point at
-`/llms.txt`, which no crawler would otherwise know to look for.
+disallowed — every published page is meant to be read — and its real purpose here is to point at the
+other two files, which no crawler would otherwise know to look for: `/llms.txt` in a comment, and
+`/sitemap.xml` in the `Sitemap` field crawlers actually parse.
+
+## `/sitemap.xml`
+
+A [sitemap](https://www.sitemaps.org/protocol.html) with one entry per project: the **static** address
+of its newest version's `index.html`, dated by the day that version was published.
+
+That is one entry point, not one entry per page. From a version's index the crawler follows the
+documentation's own links, which are relative and stay inside that version. A project whose newest
+version has no `index.html` is left out, so that every `<loc>` in the file answers `200`.
+
+Superseded versions are not listed — a search engine counts them as duplicated content. A client that
+wants them all asks `/api/projects/<project>/versions`, which `llms.txt` points at through
+`/openapi.json`.
+
+:::note[Two different files called `sitemap.xml`]
+
+A Docusaurus project ships a `sitemap.xml` of its own inside each published version, and **vdoc** lists
+those under `## Page indexes` in `llms.txt`. That file covers the pages of one version of one project.
+This one covers the whole instance. They are unrelated, and the per-version file is the more useful of
+the two if what you want is every page of a project.
+
+:::
 
 ## Configuring what they say
 
-Neither file has settings of its own. The name and the summary come from the
+None of the three files has settings of its own. The name and the summary come from the
 [site plugin](04-plugins/02-site.md), the grouping from `project_categories` and
 `project_category_mapping` in the [configuration](03-configuration.md#configuration-file), and
 everything else from the documentation directory.
@@ -68,16 +110,22 @@ still renders, under a generic heading.
 
 ## Absolute URLs and reverse proxies
 
-Both files list absolute URLs, so that they keep working once copied away from the site they came from.
-The host is taken from the request, honoring `X-Forwarded-Proto` and `X-Forwarded-Host` so that a
+All three files list absolute URLs, so that they keep working once copied away from the site they came
+from. The host is taken from the request, honoring `X-Forwarded-Proto` and `X-Forwarded-Host` so that a
 **vdoc** behind a reverse proxy names the address readers actually use rather than its own container.
+
+The `Link` header names a path rather than a URL, which a client resolves against the address it just
+requested.
 
 ## Trying it
 
 ```sh
 curl https://your-vdoc.example.com/llms.txt
 curl https://your-vdoc.example.com/robots.txt
+curl https://your-vdoc.example.com/sitemap.xml
+curl -sI https://your-vdoc.example.com/my-project/latest/index.html | grep -i '^link:'
 ```
 
-A useful check, if something looks wrong: every link in `llms.txt` should answer `200`. A readable
-address that answers `404` means the version is gone; a static address that does means the file is.
+A useful check, if something looks wrong: every link in `llms.txt` and every `<loc>` in `sitemap.xml`
+should answer `200`. A readable address that answers `404` means the version is gone; a static address
+that does means the file is.

--- a/docs/docs/06-frame-contract.md
+++ b/docs/docs/06-frame-contract.md
@@ -173,6 +173,10 @@ So every page has two addresses, and mapping between them is a pure function in 
 vdoc's own parameters never appear in the readable form. They are requests to the frame, not part of
 a page's address.
 
+A client that fetches the readable address without running scripts gets a `Link` header naming the
+static one, so the mapping does not have to be known in advance.
+[Agent and crawler discovery](05-agent-discovery.md) covers that, and the files a crawler looks for.
+
 `latest` stands in for a version in the static form as well, so `/static/projects/proj/latest/page.html`
 redirects to whichever version is newest. A redirect rather than the file itself, because a relative
 link inside the page resolves against the address the browser ended up on, and that has to be the
@@ -180,9 +184,7 @@ resolved version for the link to stay inside it.
 
 **A request for something unpublished is answered honestly.** vdoc serves its own application under a
 **404** when the path names no project it has, or no version it published. A reader still gets vdoc's
-not-found page; a crawler, a link checker or an agent is told the truth. Answering 200 for every path
-made the fallback route the one that never fails, which left `/robots.txt` and every typo looking like
-a published document.
+not-found page; a crawler, a link checker or an agent is told the truth.
 
 ## What vdoc does around the frame
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -29,8 +29,8 @@ The [voraus robotik GmbH](https://www.vorausrobotik.com/) software documentation
   newest. → [Publishing documentation](02-publishing.md)
 - **Looks like your organization.** Title, logo, colors, footer links and search are configuration,
   not a fork. → [Plugins](04-plugins/index.mdx)
-- **Answers machines as well as people.** `/llms.txt` and `/robots.txt` are generated from what is
-  actually published. → [Agent and crawler discovery](05-agent-discovery.md)
+- **Answers machines as well as people.** `/llms.txt`, `/sitemap.xml` and `/robots.txt` are generated
+  from what is actually published. → [Agent and crawler discovery](05-agent-discovery.md)
 - **Stays consistent across generators.** vdoc renders the chrome, the framed site hides its own.
   → [The frame contract](06-frame-contract.md)
 

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -9,6 +9,20 @@
 
   <body>
     <div id="root"></div>
+    <!--
+      What a client that does not run scripts is told, since what it received is otherwise an empty
+      document with nothing in it pointing anywhere. Deliberately free of any address of this page: it
+      is served verbatim for every route, and the rule it states holds for all of them.
+    -->
+    <noscript>
+      <p>
+        This page is rendered by a JavaScript application. Every documentation page is also served as plain HTML,
+        without one: prefix the path of this page with <code>/static/projects</code>.
+      </p>
+      <p>
+        An index of everything published here, written for automated readers, is at <a href="/llms.txt">/llms.txt</a>.
+      </p>
+    </noscript>
     <script type="module" src="main.tsx"></script>
   </body>
 </html>

--- a/src/vdoc/api/lifespan.py
+++ b/src/vdoc/api/lifespan.py
@@ -3,6 +3,7 @@
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from pathlib import Path
+from urllib.parse import quote
 
 from fastapi import FastAPI, status
 from fastapi.routing import Mount
@@ -156,6 +157,28 @@ def _resolve_webapp_asset(file_path: str) -> Path | None:
     return asset_path if asset_path.is_file() else None
 
 
+def _static_alternate(file_path: str) -> str | None:
+    """Returns the static address of the page a readable request path names.
+
+    The two namespaces map onto each other by nothing but the prefix, so this is the whole conversion.
+    A path naming no version has no page behind it -- the project landing page is vdoc's own, not a
+    published file -- and gets none.
+
+    Args:
+        file_path: The requested file path.
+
+    Returns:
+        The static address, or None if the path does not name a page within a version.
+    """
+    if len([segment for segment in file_path.split("/") if segment]) < 2:  # noqa: PLR2004
+        return None
+
+    # Percent-encoded, because this is composed into a response header out of a request path, and a
+    # request path is untrusted. Encoding it is what keeps a crafted one from ending the header field
+    # and writing another.
+    return f"{STATIC_PROJECTS_PREFIX}/{quote(file_path.lstrip('/'), safe='/')}"
+
+
 def _is_frontend_route(file_path: str) -> bool:
     """Reports whether the web UI has a route for a request path.
 
@@ -190,6 +213,11 @@ def _include_frontend_router(fastapi: FastAPI) -> FastAPI:
         checker is told the truth. Answering 200 for every path made this the last route that never
         fails, which left `/robots.txt` and every typo looking like a published document.
 
+        What it answers a documentation page with is an empty shell until scripts run, so the response
+        carries a `Link` header naming the static address of that same page. That is the one pointer an
+        automated client gets without having been told to look in `/robots.txt` or `/llms.txt` first --
+        it arrives in the answer to the address a person would have pasted.
+
         Args:
             file_path (str): The requested file path.
 
@@ -199,9 +227,13 @@ def _include_frontend_router(fastapi: FastAPI) -> FastAPI:
         if (asset_path := _resolve_webapp_asset(file_path=file_path)) is not None:
             return FileResponse(path=asset_path)
 
+        is_route = _is_frontend_route(file_path=file_path)
+        alternate = _static_alternate(file_path=file_path) if is_route else None
+
         return FileResponse(
             path=webapp_path / "index.html",
-            status_code=status.HTTP_200_OK if _is_frontend_route(file_path=file_path) else status.HTTP_404_NOT_FOUND,
+            status_code=status.HTTP_200_OK if is_route else status.HTTP_404_NOT_FOUND,
+            headers={"Link": f'<{alternate}>; rel="alternate"; type="text/html"'} if alternate else None,
         )
 
     return fastapi

--- a/src/vdoc/api/lifespan.py
+++ b/src/vdoc/api/lifespan.py
@@ -95,8 +95,8 @@ def _include_intersphinx_router(fastapi: FastAPI) -> FastAPI:
         Returns:
             FileResponse: The objects.inv file.
         """
-        served_version = get_project_version_impl(name=project_name, version=version)
-        inventory_path = get_settings().docs_dir / project_name / served_version / _SPHINX_INVENTORY_FILE_NAME
+        served_version, version_path = Project.get_version_and_docs_path(name=project_name, version=version)
+        inventory_path = version_path / _SPHINX_INVENTORY_FILE_NAME
 
         # Only a generator that builds on Sphinx writes one. Without this check, asking a version built by
         # any other generator for its inventory raises out of FileResponse as a 500.

--- a/src/vdoc/api/routes/agent_discovery.py
+++ b/src/vdoc/api/routes/agent_discovery.py
@@ -1,10 +1,15 @@
 """Contains the routes an automated reader looks for."""
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Response
 from fastapi.responses import PlainTextResponse
 from starlette.requests import Request
 
-from vdoc.methods.api.agent_discovery import get_public_base_url, render_llms_txt_impl, render_robots_txt_impl
+from vdoc.methods.api.agent_discovery import (
+    get_public_base_url,
+    render_llms_txt_impl,
+    render_robots_txt_impl,
+    render_sitemap_xml_impl,
+)
 
 router = APIRouter(tags=["Agent discovery"])
 
@@ -22,9 +27,25 @@ def get_llms_txt(request: Request) -> PlainTextResponse:
     return PlainTextResponse(content=render_llms_txt_impl(base_url=get_public_base_url(request=request)))
 
 
+@router.get("/sitemap.xml", response_class=Response)
+def get_sitemap_xml(request: Request) -> Response:
+    """Serves the ``sitemap.xml`` listing the entry point of every published project.
+
+    Args:
+        request: The incoming request, which is what knows the public base URL to link to.
+
+    Returns:
+        The rendered ``sitemap.xml``.
+    """
+    return Response(
+        content=render_sitemap_xml_impl(base_url=get_public_base_url(request=request)),
+        media_type="application/xml",
+    )
+
+
 @router.get("/robots.txt", response_class=PlainTextResponse)
 def get_robots_txt(request: Request) -> PlainTextResponse:
-    """Serves ``robots.txt``, which points at ``llms.txt``.
+    """Serves ``robots.txt``, which points at ``llms.txt`` and at ``sitemap.xml``.
 
     Args:
         request: The incoming request, which is what knows the public base URL to link to.

--- a/src/vdoc/methods/api/agent_discovery.py
+++ b/src/vdoc/methods/api/agent_discovery.py
@@ -1,9 +1,12 @@
 """Contains the documents that tell an automated reader what this instance holds.
 
-``/llms.txt`` follows https://llmstxt.org and ``/robots.txt`` follows RFC 9309. Both are rendered from
-templates in ``vdoc/templates`` and derived from what is actually published, so an upload is enough to
-appear in them. The "Agent and crawler discovery" page of the documentation says what they contain.
+``/llms.txt`` follows https://llmstxt.org, ``/robots.txt`` follows RFC 9309 and ``/sitemap.xml`` follows
+the sitemaps protocol. All three are rendered from templates in ``vdoc/templates`` and derived from what
+is actually published, so an upload is enough to appear in them. The "Agent and crawler discovery" page
+of the documentation says what they contain.
 """
+
+from datetime import UTC, datetime
 
 from jinja2 import Environment, PackageLoader, select_autoescape
 from starlette.requests import Request
@@ -103,6 +106,51 @@ def _inventories(projects: list[Project]) -> list[tuple[Project, str, str]]:
     ]
 
 
+def _listable_projects() -> list[Project]:
+    """Returns the projects these documents can name.
+
+    Returns:
+        Every project that has a version to link to. A project directory without a parsable version in it
+        has none, and asking it for its latest version would raise -- leaving it out keeps one broken
+        upload from taking the whole document down.
+    """
+    return [project for project in Project.list() if project.versions]
+
+
+def _entry_points(projects: list[Project], base_url: str) -> list[tuple[str, str]]:
+    """Collects the static address a crawler should enter each project at, and when it last changed.
+
+    The newest version only. Every superseded version says nearly the same thing at a different address,
+    which is what a search engine counts as duplicated content, and the versions API enumerates them for
+    a client that wants them all.
+
+    Args:
+        projects: The projects to enter.
+        base_url: The absolute base URL of this vdoc instance, without a trailing slash.
+
+    Returns:
+        The absolute URL and the last modification date of every project's entry point, skipping the
+        projects whose newest version has no page to enter at.
+    """
+    docs_dir = get_settings().docs_dir
+    entry_points = []
+
+    for project in projects:
+        version_dir = docs_dir / project.name / project.latest
+        if not (version_dir / "index.html").is_file():
+            continue
+
+        # A version directory is written once, when it is published, so its modification time is the date
+        # that version appeared. To the day: the hour a ZIP happened to be uploaded at means nothing to a
+        # crawler deciding whether to come back.
+        published_on = datetime.fromtimestamp(version_dir.stat().st_mtime, tz=UTC).date()
+        location = f"{base_url}{STATIC_PROJECTS_PREFIX}/{project.name}/{project.latest}/index.html"
+
+        entry_points.append((location, published_on.isoformat()))
+
+    return entry_points
+
+
 def render_llms_txt_impl(base_url: str) -> str:
     """Renders the ``llms.txt`` index of everything currently published.
 
@@ -113,10 +161,7 @@ def render_llms_txt_impl(base_url: str) -> str:
         The rendered ``llms.txt`` as markdown.
     """
     site = SitePlugin()
-
-    # A project directory without a parsable version in it has nothing to link to, and asking it for its
-    # latest version would raise. Leaving it out keeps one broken upload from taking the index down.
-    projects = [project for project in Project.list() if project.versions]
+    projects = _listable_projects()
 
     return _templates.get_template("llms.txt.j2").render(
         title=site.title or DEFAULT_SITE_TITLE,
@@ -127,6 +172,20 @@ def render_llms_txt_impl(base_url: str) -> str:
         base_url=base_url,
         static_prefix=STATIC_PROJECTS_PREFIX,
         latest_alias=LATEST_VERSION_ALIAS,
+    )
+
+
+def render_sitemap_xml_impl(base_url: str) -> str:
+    """Renders the ``sitemap.xml`` a crawler is pointed at from ``robots.txt``.
+
+    Args:
+        base_url: The absolute base URL of this vdoc instance, without a trailing slash.
+
+    Returns:
+        The rendered ``sitemap.xml``.
+    """
+    return _templates.get_template("sitemap.xml.j2").render(
+        urls=_entry_points(projects=_listable_projects(), base_url=base_url),
     )
 
 

--- a/src/vdoc/methods/api/agent_discovery.py
+++ b/src/vdoc/methods/api/agent_discovery.py
@@ -6,7 +6,8 @@ is actually published, so an upload is enough to appear in them. The "Agent and 
 of the documentation says what they contain.
 """
 
-from datetime import UTC, datetime
+from collections.abc import Sequence
+from functools import partial
 
 from jinja2 import Environment, PackageLoader, select_autoescape
 from starlette.requests import Request
@@ -60,7 +61,7 @@ def get_public_base_url(request: Request) -> str:
     return f"{scheme}://{host}"
 
 
-def _sections(projects: list[Project]) -> list[tuple[str, list[Project]]]:
+def _sections(projects: Sequence[Project]) -> list[tuple[str, list[Project]]]:
     """Groups projects into their configured categories, in the order the categories are configured.
 
     Projects without a category are collected into a trailing section, so that a partially categorized
@@ -87,7 +88,23 @@ def _sections(projects: list[Project]) -> list[tuple[str, list[Project]]]:
     return [(title, section_projects) for title, section_projects in sections if section_projects]
 
 
-def _inventories(projects: list[Project]) -> list[tuple[Project, str, str]]:
+def _static_url(base_url: str, project: Project, file_name: str) -> str:
+    """Returns the address a file of a project's newest version is served at.
+
+    Both documents link the same addresses, so both compose them here.
+
+    Args:
+        base_url: The absolute base URL of this vdoc instance, without a trailing slash.
+        project: The project the file belongs to.
+        file_name: The name of the file, relative to the version's root.
+
+    Returns:
+        The absolute static address of that file.
+    """
+    return f"{base_url}{STATIC_PROJECTS_PREFIX}/{project.name}/{project.latest}/{file_name}"
+
+
+def _inventories(projects: Sequence[Project]) -> list[tuple[Project, str, str]]:
     """Collects the page inventories the newest version of each project actually ships.
 
     Args:
@@ -96,28 +113,15 @@ def _inventories(projects: list[Project]) -> list[tuple[Project, str, str]]:
     Returns:
         The project, file name and description of every inventory file present.
     """
-    docs_dir = get_settings().docs_dir
-
     return [
         (project, file_name, description)
         for project in projects
         for file_name, description in PAGE_INVENTORY_FILES.items()
-        if (docs_dir / project.name / project.latest / file_name).is_file()
+        if project.latest_contains(file_name)
     ]
 
 
-def _listable_projects() -> list[Project]:
-    """Returns the projects these documents can name.
-
-    Returns:
-        Every project that has a version to link to. A project directory without a parsable version in it
-        has none, and asking it for its latest version would raise -- leaving it out keeps one broken
-        upload from taking the whole document down.
-    """
-    return [project for project in Project.list() if project.versions]
-
-
-def _entry_points(projects: list[Project], base_url: str) -> list[tuple[str, str]]:
+def _entry_points(projects: Sequence[Project], base_url: str) -> list[tuple[str, str]]:
     """Collects the static address a crawler should enter each project at, and when it last changed.
 
     The newest version only. Every superseded version says nearly the same thing at a different address,
@@ -129,26 +133,17 @@ def _entry_points(projects: list[Project], base_url: str) -> list[tuple[str, str
         base_url: The absolute base URL of this vdoc instance, without a trailing slash.
 
     Returns:
-        The absolute URL and the last modification date of every project's entry point, skipping the
-        projects whose newest version has no page to enter at.
+        The absolute URL and the publication date of every project's entry point, skipping the projects
+        whose newest version has no page to enter at.
     """
-    docs_dir = get_settings().docs_dir
-    entry_points = []
-
-    for project in projects:
-        version_dir = docs_dir / project.name / project.latest
-        if not (version_dir / "index.html").is_file():
-            continue
-
-        # A version directory is written once, when it is published, so its modification time is the date
-        # that version appeared. To the day: the hour a ZIP happened to be uploaded at means nothing to a
-        # crawler deciding whether to come back.
-        published_on = datetime.fromtimestamp(version_dir.stat().st_mtime, tz=UTC).date()
-        location = f"{base_url}{STATIC_PROJECTS_PREFIX}/{project.name}/{project.latest}/index.html"
-
-        entry_points.append((location, published_on.isoformat()))
-
-    return entry_points
+    return [
+        (
+            _static_url(base_url=base_url, project=project, file_name="index.html"),
+            project.latest_published_on.isoformat(),
+        )
+        for project in projects
+        if project.latest_contains("index.html")
+    ]
 
 
 def render_llms_txt_impl(base_url: str) -> str:
@@ -161,7 +156,7 @@ def render_llms_txt_impl(base_url: str) -> str:
         The rendered ``llms.txt`` as markdown.
     """
     site = SitePlugin()
-    projects = _listable_projects()
+    projects = Project.list_published()
 
     return _templates.get_template("llms.txt.j2").render(
         title=site.title or DEFAULT_SITE_TITLE,
@@ -169,6 +164,7 @@ def render_llms_txt_impl(base_url: str) -> str:
         long_description=site.long_description or (),
         sections=_sections(projects=projects),
         inventories=_inventories(projects=projects),
+        static=partial(_static_url, base_url),
         base_url=base_url,
         static_prefix=STATIC_PROJECTS_PREFIX,
         latest_alias=LATEST_VERSION_ALIAS,
@@ -185,7 +181,7 @@ def render_sitemap_xml_impl(base_url: str) -> str:
         The rendered ``sitemap.xml``.
     """
     return _templates.get_template("sitemap.xml.j2").render(
-        urls=_entry_points(projects=_listable_projects(), base_url=base_url),
+        urls=_entry_points(projects=Project.list_published(), base_url=base_url),
     )
 
 

--- a/src/vdoc/models/project.py
+++ b/src/vdoc/models/project.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import UTC, date, datetime
 from functools import cached_property, lru_cache
 from typing import TYPE_CHECKING
 
@@ -15,6 +16,7 @@ from vdoc.exceptions import InvalidVersion, ProjectNotFound, ProjectVersionNotFo
 from vdoc.settings import get_settings
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
 
 
@@ -140,6 +142,18 @@ class Project(BaseModel):
         return sorted(projects, key=lambda project: project.name)
 
     @classmethod
+    def list_published(cls) -> Sequence[Project]:
+        """Returns every project that has a version to serve.
+
+        A project directory holding nothing that parses as a version has none, and asking it for its
+        latest version raises.
+
+        Returns:
+            The projects with at least one published version.
+        """
+        return [project for project in cls.list() if project.versions]
+
+    @classmethod
     def is_published(cls, name: str, version: str | None = None) -> bool:
         """Reports whether a project, and if given a version of it, is published.
 
@@ -203,7 +217,7 @@ class Project(BaseModel):
             if parsed_version.public not in _published(project_path=project._base_path).public_forms:
                 raise ProjectVersionNotFound(name=name, version=parsed_version)
 
-        return return_version, project._base_path / return_version  # Path existence is validated at object construction
+        return return_version, project.version_path(version=return_version)
 
     @computed_field  # type: ignore[prop-decorator]  # https://docs.pydantic.dev/2.0/usage/computed_fields/
     @cached_property
@@ -246,6 +260,52 @@ class Project(BaseModel):
         """Returns the latest version available of the project.
 
         Returns:
-            _description_
+            The newest published version of the project.
         """
         return _published(project_path=self._base_path).ordered[-1][1]
+
+    def version_path(self, version: str) -> Path:
+        """Returns the directory a published version of this project is served from.
+
+        The one place that knows how a version maps onto a location, so that whoever needs a file of a
+        version asks for it here instead of composing the layout again.
+
+        Args:
+            version: The version, spelled as it is published.
+
+        Returns:
+            The directory holding that version.
+        """
+        return self._base_path / version
+
+    @property
+    def latest_path(self) -> Path:
+        """Returns the directory the newest published version is served from.
+
+        Returns:
+            The directory holding the newest published version.
+        """
+        return self.version_path(version=self.latest)
+
+    @property
+    def latest_published_on(self) -> date:
+        """Returns the day the newest published version appeared.
+
+        A version directory is written once, when it is published, so its modification time is when
+        that version arrived.
+
+        Returns:
+            The publication date of the newest published version.
+        """
+        return datetime.fromtimestamp(self.latest_path.stat().st_mtime, tz=UTC).date()
+
+    def latest_contains(self, file_name: str) -> bool:
+        """Reports whether the newest published version ships a file.
+
+        Args:
+            file_name: The name of the file, relative to the version's root.
+
+        Returns:
+            True if the newest published version contains it, False otherwise.
+        """
+        return (self.latest_path / file_name).is_file()

--- a/src/vdoc/models/project.py
+++ b/src/vdoc/models/project.py
@@ -242,7 +242,7 @@ class Project(BaseModel):
             return next(category.id for category in settings.project_categories if category.name == category_name)
         return None
 
-    @property
+    @cached_property
     def versions(self) -> dict[Version, str]:
         """Returns a list of all available project versions.
 
@@ -252,10 +252,12 @@ class Project(BaseModel):
         Returns:
             A list of all versions of the project.
         """
-        # Path existence is validated at object construction
+        # Cached per instance, like everything derived from it: a Project is built per request and never
+        # outlives the upload that would change the answer. `_scan_versions` holds the cache that spans
+        # requests; this one keeps rendering a document from re-reading the same project a dozen times.
         return dict(_published(project_path=self._base_path).ordered)
 
-    @property
+    @cached_property
     def latest(self) -> str:
         """Returns the latest version available of the project.
 

--- a/src/vdoc/templates/llms.txt.j2
+++ b/src/vdoc/templates/llms.txt.j2
@@ -28,6 +28,10 @@ application that renders the page inside a frame, so a plain HTTP fetch of it re
 The static one, `{{ static_prefix }}/<project>/<version>/<page>`, is the page itself as server-rendered
 HTML. Fetch the static address.
 
+Quote the readable one. The two differ by nothing but the `{{ static_prefix }}` prefix, and a person
+handed a link wants the page inside the interface, with its navigation, version picker and search,
+rather than the bare file. Read from the static address, pass on the readable one.
+
 `{{ latest_alias }}` stands in for a version and resolves to the newest published one, so
 `{{ static_prefix }}/<project>/{{ latest_alias }}/index.html` stays correct as versions are added. The
 links below name a resolved version instead, because that is what is newest right now.
@@ -45,9 +49,9 @@ The REST API described by `{{ base_url }}/openapi.json` lists projects, versions
 
 {% endfor %}
 {% if inventories %}
-## Optional
+## Page indexes
 
-Machine-readable page indexes, for enumerating the pages of a version without crawling it:
+One request that enumerates every page of a version, instead of crawling it:
 
 {% for project, file_name, description in inventories %}
 - [{{ project.display_name }} {{ project.latest }} {{ file_name }}]({{ static(project, file_name) }}): {{ description }}

--- a/src/vdoc/templates/llms.txt.j2
+++ b/src/vdoc/templates/llms.txt.j2
@@ -8,9 +8,6 @@
   Rendered as plain text, so whitespace here is the whitespace in the answer. The environment trims
   block tags, which is why the blank lines that matter are written out literally.
 -#}
-{%- macro static(project, file_name) -%}
-{{ base_url }}{{ static_prefix }}/{{ project.name }}/{{ project.latest }}/{{ file_name }}
-{%- endmacro -%}
 # {{ title }}
 
 {% if description %}

--- a/src/vdoc/templates/robots.txt.j2
+++ b/src/vdoc/templates/robots.txt.j2
@@ -1,6 +1,9 @@
 {#-
   Nothing is disallowed: every published page is meant to be read. What this file is really for here is
   the pointer to llms.txt, which no crawler would otherwise know to look for. Format per RFC 9309.
+
+  `Sitemap` is a non-group field, so it applies to every user agent no matter where it stands. It goes
+  after the group because that is where a reader looks for it.
 -#}
 # Documentation served by vdoc: https://github.com/vorausrobotik/vdoc
 #
@@ -12,3 +15,5 @@
 
 User-agent: *
 Allow: /
+
+Sitemap: {{ base_url }}/sitemap.xml

--- a/src/vdoc/templates/sitemap.xml.j2
+++ b/src/vdoc/templates/sitemap.xml.j2
@@ -1,0 +1,20 @@
+{#-
+  The sitemap a crawler looks for, per https://www.sitemaps.org/protocol.html, pointed at from robots.txt.
+
+  It lists static addresses, because those are the ones that carry the page. The readable address of the
+  same page renders it in a JavaScript application, which a crawler that does not run scripts reads as an
+  empty document -- listing those would offer a crawler nothing to index.
+
+  One entry point per project rather than every page: from a version's index the crawler follows the
+  documentation's own links, which are relative and stay inside that version. Rendered as XML, so the
+  environment escapes what is interpolated.
+-#}
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{% for location, last_modified in urls %}
+  <url>
+    <loc>{{ location }}</loc>
+    <lastmod>{{ last_modified }}</lastmod>
+  </url>
+{% endfor %}
+</urlset>

--- a/tests/unit/api/routes/test_agent_discovery.py
+++ b/tests/unit/api/routes/test_agent_discovery.py
@@ -1,11 +1,14 @@
 """Contains all unit tests for the documents written for automated readers."""
 
 import os
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import patch
+from xml.etree import ElementTree as ET
 
 import pytest
 from fastapi.testclient import TestClient
+from httpx import Response
 
 from vdoc.constants import CONFIG_ENV_PREFIX_PLUGINS
 
@@ -68,14 +71,29 @@ def test_llms_txt_advertises_only_the_inventories_that_exist(dummy_projects_dir:
 
     body = api.get("/llms.txt").text
 
-    assert "## Optional" in body
+    assert "## Page indexes" in body
     assert "http://testserver/static/projects/dummy-project-01/2.0.0/objects.inv" in body
     assert "http://testserver/static/projects/dummy-project-02/6.0/sitemap.xml" in body
-    assert "dummy-project-03" not in body.split("## Optional")[1]
+    assert "dummy-project-03" not in body.split("## Page indexes")[1]
 
 
-def test_llms_txt_without_any_inventory_has_no_optional_section(dummy_projects_dir: Path, api: TestClient) -> None:  # noqa: ARG001
+def test_llms_txt_does_not_call_the_page_indexes_optional(dummy_projects_dir: Path, api: TestClient) -> None:
+    """`## Optional` is the one heading llmstxt.org defines, and it means the links under it are skippable."""
+    (dummy_projects_dir / "dummy-project-01" / "2.0.0" / "objects.inv").write_text("dummy inventory")
+
     assert "## Optional" not in api.get("/llms.txt").text
+
+
+def test_llms_txt_without_any_inventory_has_no_page_index_section(dummy_projects_dir: Path, api: TestClient) -> None:  # noqa: ARG001
+    assert "## Page indexes" not in api.get("/llms.txt").text
+
+
+def test_llms_txt_says_which_address_to_pass_on(dummy_projects_dir: Path, api: TestClient) -> None:  # noqa: ARG001
+    """An agent that cites what it read must hand a person the readable address, not the static one."""
+    body = api.get("/llms.txt").text
+
+    assert "Quote the readable one." in body
+    assert "Read from the static address, pass on the readable one." in body
 
 
 def test_llms_txt_groups_projects_into_configured_categories(
@@ -142,6 +160,7 @@ def test_robots_txt_allows_everything_and_points_at_llms_txt(api: TestClient) ->
     assert "User-agent: *" in response.text
     assert "Allow: /" in response.text
     assert "http://testserver/llms.txt" in response.text
+    assert "Sitemap: http://testserver/sitemap.xml" in response.text
     assert "Disallow" not in response.text
 
 
@@ -149,7 +168,68 @@ def test_robots_txt_uses_the_forwarded_host(api: TestClient) -> None:
     body = api.get("/robots.txt", headers={"x-forwarded-proto": "https", "x-forwarded-host": "docs.example.com"}).text
 
     assert "https://docs.example.com/llms.txt" in body
+    assert "https://docs.example.com/sitemap.xml" in body
     assert "testserver" not in body
+
+
+def _sitemap_locations(response: Response) -> list[str]:
+    """Returns the URL of every entry of a sitemap, parsed rather than matched as text."""
+    namespace = {"sitemap": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    root = ET.fromstring(response.text)  # noqa: S314
+
+    return [element.text or "" for element in root.findall("sitemap:url/sitemap:loc", namespace)]
+
+
+def test_sitemap_xml_is_served_as_xml(dummy_projects_dir: Path, api: TestClient) -> None:  # noqa: ARG001
+    response = api.get("/sitemap.xml")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/xml")
+
+
+def test_sitemap_xml_lists_the_newest_version_of_every_project(dummy_projects_dir: Path, api: TestClient) -> None:  # noqa: ARG001
+    locations = _sitemap_locations(api.get("/sitemap.xml"))
+
+    assert locations == [
+        "http://testserver/static/projects/dummy-project-01/2.0.0/index.html",
+        "http://testserver/static/projects/dummy-project-02/6.0/index.html",
+        "http://testserver/static/projects/dummy-project-03/2.0.0-beta/index.html",
+    ]
+
+
+def test_sitemap_xml_dates_an_entry_by_when_its_version_was_published(
+    dummy_projects_dir: Path,
+    api: TestClient,
+) -> None:
+    published_on = datetime.fromtimestamp(
+        (dummy_projects_dir / "dummy-project-01" / "2.0.0").stat().st_mtime, tz=UTC
+    ).date()
+
+    assert f"<lastmod>{published_on.isoformat()}</lastmod>" in api.get("/sitemap.xml").text
+
+
+def test_sitemap_xml_skips_a_version_without_a_page_to_enter_at(dummy_projects_dir: Path, api: TestClient) -> None:
+    """An entry a crawler would receive a 404 for is worse than no entry at all."""
+    (dummy_projects_dir / "dummy-project-02" / "6.0" / "index.html").unlink()
+
+    assert not any("dummy-project-02" in location for location in _sitemap_locations(api.get("/sitemap.xml")))
+
+
+def test_sitemap_xml_uses_the_forwarded_host_and_scheme(dummy_projects_dir: Path, api: TestClient) -> None:  # noqa: ARG001
+    response = api.get("/sitemap.xml", headers={"x-forwarded-proto": "https", "x-forwarded-host": "docs.example.com"})
+
+    assert _sitemap_locations(response)[0].startswith("https://docs.example.com/")
+    assert "testserver" not in response.text
+
+
+def test_sitemap_xml_on_an_empty_instance(tmp_path: Path, request: pytest.FixtureRequest) -> None:
+    """Nothing published is an empty sitemap, which is still a valid one."""
+    with patch.dict(os.environ, {"VDOC_DOCS_DIR": str(tmp_path)}, clear=True):
+        api: TestClient = request.getfixturevalue("api")
+        response = api.get("/sitemap.xml")
+
+    assert response.status_code == 200
+    assert _sitemap_locations(response) == []
 
 
 def test_llms_txt_before_the_docs_directory_exists(tmp_path: Path, request: pytest.FixtureRequest) -> None:

--- a/tests/unit/api/routes/test_misc_routes.py
+++ b/tests/unit/api/routes/test_misc_routes.py
@@ -74,8 +74,9 @@ def test_serve_frontend_assets_rejects_path_traversal(
         ("/not-a-project/1.0.0", 404),
         ("/dummy-project-01/9.9.9", 404),
         ("/dummy-project-01/not-a-version", 404),
-        # `/robots.txt` and `/llms.txt` are served for real, see test_agent_discovery.py
-        ("/sitemap.xml", 404),
+        # A conventional root file vdoc does not serve. The ones it does -- `/robots.txt`, `/llms.txt`
+        # and `/sitemap.xml` -- never reach this route, see test_agent_discovery.py
+        ("/humans.txt", 404),
     ],
 )
 def test_serve_frontend_index_status_codes(
@@ -94,6 +95,61 @@ def test_serve_frontend_index_status_codes(
 
     assert response.status_code == expected_status_code
     assert response.text == "dummy index.html content"
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_link"),
+    [
+        (
+            "/dummy-project-01/1.0.0/api.html",
+            '</static/projects/dummy-project-01/1.0.0/api.html>; rel="alternate"; type="text/html"',
+        ),
+        (
+            "/dummy-project-01/latest/guide/page.html",
+            '</static/projects/dummy-project-01/latest/guide/page.html>; rel="alternate"; type="text/html"',
+        ),
+        # The version alone is a page too: it is the version's index
+        (
+            "/dummy-project-01/1.0.0",
+            '</static/projects/dummy-project-01/1.0.0>; rel="alternate"; type="text/html"',
+        ),
+        # vdoc's own pages, which no published file stands behind
+        ("/", None),
+        ("/dummy-project-01", None),
+        # Nothing published answers this, so there is nothing to point at
+        ("/not-a-project/1.0.0/index.html", None),
+    ],
+)
+def test_serve_frontend_index_points_at_the_static_address(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    dummy_projects_dir: Path,  # noqa: ARG001
+    api: TestClient,
+    path: str,
+    expected_link: str | None,
+) -> None:
+    """The shell says where the page itself is, for a client that reached the readable address first."""
+    (tmp_path / "index.html").write_text("dummy index.html content")
+    monkeypatch.setattr("vdoc.api.lifespan.webapp_path", tmp_path)
+
+    response = api.get(path)
+
+    assert response.headers.get("link") == expected_link
+
+
+def test_serve_frontend_index_encodes_the_static_address(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    dummy_projects_dir: Path,  # noqa: ARG001
+    api: TestClient,
+) -> None:
+    """The path is composed into a header, so what a header may not contain must not survive into one."""
+    (tmp_path / "index.html").write_text("dummy index.html content")
+    monkeypatch.setattr("vdoc.api.lifespan.webapp_path", tmp_path)
+
+    response = api.get("/dummy-project-01/1.0.0/a%20page%3E.html")
+
+    assert response.headers["link"].startswith("</static/projects/dummy-project-01/1.0.0/a%20page%3E.html>")
 
 
 def test_static_latest_redirects_to_the_published_version(dummy_projects_dir: Path, api: TestClient) -> None:  # noqa: ARG001

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -55,6 +55,14 @@ def test_list_published_projects(dummy_projects_dir: Path) -> None:
     assert Project.list_published() == [Project(name=project_name) for project_name in DUMMY_DOCS_STRUCTURE]
 
 
+def test_project_equality_survives_its_caches(dummy_projects_dir: Path) -> None:  # noqa: ARG001
+    """What a project has been asked must not change what makes it the same project."""
+    read, untouched = Project(name="dummy-project-01"), Project(name="dummy-project-01")
+    _ = read.latest, read.versions, read.display_name
+
+    assert read == untouched
+
+
 def test_project_version_path(dummy_projects_dir: Path) -> None:
     project = Project(name="dummy-project-01")
 

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -1,6 +1,7 @@
 """Contains all tests for the project models."""
 
 import os
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import patch
 
@@ -45,6 +46,36 @@ def test_list_project_versions(dummy_projects_dir: Path) -> None:  # noqa: ARG00
 
 def test_get_project_latest_version(dummy_projects_dir: Path) -> None:  # noqa: ARG001
     assert Project(name="dummy-project-03").latest == "2.0.0-beta"
+
+
+def test_list_published_projects(dummy_projects_dir: Path) -> None:
+    """A project directory with nothing publishable in it must not reach whoever lists projects."""
+    (dummy_projects_dir / "empty-project").mkdir()
+
+    assert Project.list_published() == [Project(name=project_name) for project_name in DUMMY_DOCS_STRUCTURE]
+
+
+def test_project_version_path(dummy_projects_dir: Path) -> None:
+    project = Project(name="dummy-project-01")
+
+    assert project.version_path(version="1.1.0") == dummy_projects_dir / "dummy-project-01" / "1.1.0"
+    assert project.latest_path == dummy_projects_dir / "dummy-project-01" / "2.0.0"
+
+
+def test_project_latest_contains(dummy_projects_dir: Path) -> None:
+    project = Project(name="dummy-project-01")
+    (dummy_projects_dir / "dummy-project-01" / "1.1.0" / "objects.inv").write_text("only in a superseded version")
+
+    assert project.latest_contains("index.html")
+    assert not project.latest_contains("objects.inv")
+
+
+def test_project_latest_published_on(dummy_projects_dir: Path) -> None:
+    published_on = datetime.fromtimestamp(
+        (dummy_projects_dir / "dummy-project-01" / "2.0.0").stat().st_mtime, tz=UTC
+    ).date()
+
+    assert Project(name="dummy-project-01").latest_published_on == published_on
 
 
 def test_get_version_and_docs_path(dummy_projects_dir: Path) -> None:


### PR DESCRIPTION
A page's readable address answers with the web UI, which is an empty document to anything that does not run scripts. This branch makes the page behind it findable without a browser, and tells an agent which of the two addresses to hand back to a person.

## What changes

**`/sitemap.xml`** lists the static `index.html` of every project's newest version, dated by the day that version was published, and `robots.txt` names it in the `Sitemap` field crawlers parse. It is rendered from what is published, like `llms.txt` beside it. A project whose newest version has no `index.html` is left out, so every `<loc>` answers 200.

**The readable address now points at the page itself.** The response carries a `Link: </static/projects/…>; rel="alternate"; type="text/html"` header, and `src/ui/index.html` gained a `<noscript>` block stating the prefix rule. A client that started from a link a person shared finds the content in the response it already has, instead of having to know about `/robots.txt` first.

**`llms.txt` says which address to pass on:** fetch the static one, quote the readable one, so an agent's citation lands a reader inside the interface rather than on a bare file. Its page indexes move out of `## Optional`, which [llmstxt.org](https://llmstxt.org/) defines as links an agent may skip — the opposite of what they are.

## Refactoring that came with it

`docs_dir / <project> / <version>` was composed in four places outside the model. `Project` now answers it through `version_path()`, `latest_path`, `latest_contains()`, `latest_published_on` and `list_published()`; the renderers compose documents and no longer touch the filesystem. Moving what is published somewhere other than a directory tree is now a change to one class.

`versions` and `latest` became `cached_property` on the way. Over nine projects of 26 versions each, `/llms.txt` drops from 81 `stat()` calls per request to 18 and `/sitemap.xml` from 45 to 27.

## Verification

136 Python tests, 87 Vitest, `ruff`/`mypy`/`codespell`/`biome`/`prettier` clean, Docusaurus build green. The refactor is behavior-preserving — the existing suite passed unchanged before the new model tests were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)