### PR TITLE
fix(ui): Lay out every page for the width it is shown at

### DIFF
--- a/src/ui/components/LandingPage.tsx
+++ b/src/ui/components/LandingPage.tsx
@@ -18,12 +18,12 @@ export function LandingPage() {
     return groupProjectsByCategories(projects, projectCategories)
   }, [projects, projectCategories])
   return (
-    <Container sx={{ mt: 2 }}>
+    <Container maxWidth="xl" sx={{ mt: 2 }}>
       <SitePlugin config={sitePluginConfig} />
       {Object.entries(getGroupedProjects).map(([category, projects]) => (
         <Box key={category} sx={{ mb: 4 }} data-testid={testIDs.landingPage.projectCategories.projectCategory.main}>
           <Typography
-            variant="h6"
+            variant="h5"
             sx={{ mb: 2, textTransform: 'uppercase' }}
             data-testid={testIDs.landingPage.projectCategories.projectCategory.title}
           >
@@ -53,15 +53,17 @@ export function LandingPage() {
 
 function IndexProjectCard({ project }: { project: Project }) {
   return (
-    <Grid size={{ xs: 6, md: 4, lg: 3 }}>
+    <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
       <Card
-        sx={{ minHeight: 120 }}
+        // The minimum height keeps the cards of a row the same size. A single column has no row to
+        // match, and holding every card open there only makes the list longer than it has to be.
+        sx={{ minHeight: { xs: 'auto', sm: 120 } }}
         data-testid={testIDs.landingPage.projectCategories.projectCategory.projects.projectCard.main}
       >
         <CardContent>
           <Typography
             gutterBottom
-            sx={{ color: 'text.secondary', fontSize: 14 }}
+            variant="h6"
             data-testid={testIDs.landingPage.projectCategories.projectCategory.projects.projectCard.title}
           >
             {project.display_name}
@@ -76,7 +78,6 @@ function IndexProjectCard({ project }: { project: Project }) {
             }
             to={`/$projectName/$version/$`}
             params={{ projectName: project.name, version: 'latest', _splat: '' }}
-            size="small"
           >
             Open
           </LinkButton>

--- a/src/ui/components/MenuBar.tsx
+++ b/src/ui/components/MenuBar.tsx
@@ -1,14 +1,4 @@
-import {
-  AppBar,
-  Box,
-  Grid,
-  type SelectChangeEvent,
-  Slide,
-  Toolbar,
-  Typography,
-  useMediaQuery,
-  useTheme,
-} from '@mui/material'
+import { AppBar, Box, type SelectChangeEvent, Slide, Toolbar, Typography, useMediaQuery, useTheme } from '@mui/material'
 import { getRouteApi, useNavigate, useParams } from '@tanstack/react-router'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useContentInset } from '../contexts/ContentInsetContext'
@@ -160,27 +150,38 @@ function RightGroup() {
   )
 }
 
-export default function MenuBar({ hide = false }: { hide?: boolean }) {
+export default function MenuBar({
+  hide = false,
+  onHeightChange,
+}: {
+  hide?: boolean
+  /** Called with the height the bar occupies, which the page below has to leave free. */
+  onHeightChange?: (height: number) => void
+}) {
   const theme = useTheme()
 
   const { setContentInset } = useContentInset()
   const toolbarRef = useRef<HTMLDivElement>(null)
 
   // Report where vdoc's own header content starts, so the framed documentation can line its header
-  // up with it. Measured rather than derived from the theme: the gutter is MUI's responsive
-  // `Toolbar` default today, and a second copy of that rule would be a second thing to keep in step.
-  // Observed rather than read once, because the gutter changes with the breakpoint.
+  // up with it, and how tall the bar is, so the page below can leave that much room. Measured rather
+  // than derived from the theme: gutter and height are MUI's responsive `Toolbar` defaults today, and
+  // a second copy of those rules would be a second thing to keep in step. Observed rather than read
+  // once, because both change with the breakpoint - and the height also with the orientation.
   useEffect(() => {
     const toolbar = toolbarRef.current
     if (toolbar === null) {
       return
     }
-    const report = () => setContentInset(Number.parseFloat(window.getComputedStyle(toolbar).paddingLeft) || 0)
+    const report = () => {
+      setContentInset(Number.parseFloat(window.getComputedStyle(toolbar).paddingLeft) || 0)
+      onHeightChange?.(toolbar.getBoundingClientRect().height)
+    }
     report()
     const observer = new ResizeObserver(report)
     observer.observe(toolbar)
     return () => observer.disconnect()
-  }, [setContentInset])
+  }, [setContentInset, onHeightChange])
 
   return (
     <Slide appear={false} direction="down" in={!hide}>
@@ -193,36 +194,27 @@ export default function MenuBar({ hide = false }: { hide?: boolean }) {
         elevation={0}
       >
         <Toolbar ref={toolbarRef}>
-          <Grid
-            container
-            spacing={1}
-            sx={{
-              display: 'flex',
-              width: '100%',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-            }}
-            wrap="nowrap"
-          >
+          {/* The outer groups take the width their content needs and the search bar takes what is
+              left, so no breakpoint has to guess a column split for them. A twelfth of a phone's
+              width is not enough for a logo, which is what a fixed split gave it. */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
             {/* Logo and/or Text */}
-            <Grid id="appBarLeftGroup" size={{ xs: 1, sm: 1, md: 1, lg: 3 }}>
-              <Box sx={{ display: 'flex', justifyContent: 'flex-start' }}>
-                <LeftGroup />
-              </Box>
-            </Grid>
-            {/* Searchbar */}
-            <Grid id="appBarMiddleGroup" size={{ xs: 6, sm: 7, md: 8, lg: 6 }}>
-              <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-                <MiddleGroup />
-              </Box>
-            </Grid>
+            <Box id="appBarLeftGroup" sx={{ display: 'flex', flexShrink: 0 }}>
+              <LeftGroup />
+            </Box>
+            {/* Searchbar. `minWidth` lets it shrink below its content rather than push the groups
+                beside it off the bar. */}
+            <Box id="appBarMiddleGroup" sx={{ display: 'flex', flex: 1, minWidth: 0, justifyContent: 'center' }}>
+              <MiddleGroup />
+            </Box>
             {/* vdoc version, color mode toggle and the optional version dropdown */}
-            <Grid id="appBarRightGroup" size={{ xs: 5, sm: 4, md: 3, lg: 3 }}>
-              <Box sx={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 1 }}>
-                <RightGroup />
-              </Box>
-            </Grid>
-          </Grid>
+            <Box
+              id="appBarRightGroup"
+              sx={{ display: 'flex', flexShrink: 0, justifyContent: 'flex-end', alignItems: 'center', gap: 1 }}
+            >
+              <RightGroup />
+            </Box>
+          </Box>
         </Toolbar>
       </AppBar>
     </Slide>

--- a/src/ui/components/ProjectVersionsOverview.tsx
+++ b/src/ui/components/ProjectVersionsOverview.tsx
@@ -18,7 +18,7 @@ export function ProjectVersionsOverview() {
   }, [versions])
 
   return (
-    <Container sx={{ mt: 2 }}>
+    <Container maxWidth="xl" sx={{ mt: 2 }}>
       <Typography variant="h5" sx={{ mb: 2 }}>
         Version index of {projectName}
       </Typography>
@@ -27,42 +27,41 @@ export function ProjectVersionsOverview() {
           {Object.keys(groupedVersions)
             .reverse()
             .map((major) => (
-              <Grid size={6} key={major}>
-                <Card key={major} data-testid={testIDs.project.versionOverview.majorVersionCard.main}>
+              <Grid size={{ xs: 12, md: 6 }} key={major}>
+                {/* Full height, so the cards of a row end on the same line however many versions
+                    each of them holds. */}
+                <Card
+                  key={major}
+                  sx={{ height: '100%' }}
+                  data-testid={testIDs.project.versionOverview.majorVersionCard.main}
+                >
                   <CardContent>
                     <Stack direction="row" sx={{ alignItems: 'center', gap: 2, mb: 2 }}>
                       <SellIcon />
                       <Typography variant="h6">v{major}</Typography>
                     </Stack>
-                    <Grid
-                      container
-                      direction="row"
-                      spacing={1}
-                      sx={{
-                        justifyContent: 'flex-start',
-                        alignItems: 'center',
-                      }}
-                    >
+                    {/* The row gap leaves the "latest" badge room to sit above its chip rather than
+                        in the line above it. */}
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', columnGap: 1, rowGap: 1.5 }}>
                       {groupedVersions[Number(major)].map((version) => {
                         const chip = (
-                          <Grid key={version} sx={{ mb: 1 }}>
-                            <Chip
-                              data-testid={testIDs.project.versionOverview.majorVersionCard.versionItem.main}
-                              label={version}
-                              component="a"
-                              onClick={() =>
-                                router.navigate({
-                                  to: '/$projectName/$version/$',
-                                  from: '/$projectName/',
-                                  params: {
-                                    projectName: projectName,
-                                    version: version,
-                                  },
-                                })
-                              }
-                              clickable
-                            />
-                          </Grid>
+                          <Chip
+                            key={version}
+                            data-testid={testIDs.project.versionOverview.majorVersionCard.versionItem.main}
+                            label={version}
+                            component="a"
+                            onClick={() =>
+                              router.navigate({
+                                to: '/$projectName/$version/$',
+                                from: '/$projectName/',
+                                params: {
+                                  projectName: projectName,
+                                  version: version,
+                                },
+                              })
+                            }
+                            clickable
+                          />
                         )
                         return version === latestVersion ? (
                           <Badge
@@ -77,7 +76,7 @@ export function ProjectVersionsOverview() {
                           chip
                         )
                       })}
-                    </Grid>
+                    </Box>
                   </CardContent>
                 </Card>
               </Grid>

--- a/src/ui/components/RootLayout.tsx
+++ b/src/ui/components/RootLayout.tsx
@@ -54,6 +54,7 @@ function ThemedComponent() {
   const lastScrollY = useRef(0)
   const [hideElements, setHideElements] = useState(false)
   const [showScrollToTop, setShowScrollToTop] = useState(false)
+  const [headerHeight, setHeaderHeight] = useState(0)
   const [footerHeight, setFooterHeight] = useState(0)
 
   const footerRef = useCallback((node: HTMLDivElement | null) => {
@@ -97,7 +98,7 @@ function ThemedComponent() {
 
   return (
     <Box id="rootComponent" sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
-      <MenuBar hide={hideElements} />
+      <MenuBar hide={hideElements} onHeightChange={setHeaderHeight} />
       <Box
         data-testid="contentArea"
         sx={{
@@ -105,9 +106,11 @@ function ThemedComponent() {
           overflowY: 'auto',
           display: 'flex',
           flexDirection: 'column',
-          pt: hideElements ? 0 : '64px',
+          pt: hideElements ? 0 : `${headerHeight}px`,
           pb: hideElements ? 0 : `${footerHeight}px`,
-          transition: 'padding 0.3s',
+          // Not animated until the header has been measured, so that its first measurement lands
+          // rather than sliding the content down from zero.
+          transition: headerHeight ? 'padding 0.3s' : 'none',
         }}
       >
         <Outlet />

--- a/src/ui/components/plugins/FooterPlugin.tsx
+++ b/src/ui/components/plugins/FooterPlugin.tsx
@@ -1,5 +1,5 @@
-import { Button, Container, Divider, Grid, Link, Paper, Stack, Typography, useTheme } from '@mui/material'
-import { useEffect, useState } from 'react'
+import { Box, Button, Container, Divider, Link, Paper, Typography, useTheme } from '@mui/material'
+import { Fragment, useEffect, useState } from 'react'
 import { fetchPluginConfig } from '../../helpers/APIFunctions'
 import type FooterPluginT from '../../interfacesAndTypes/plugins/FooterPlugin'
 import { iconMap } from '../../interfacesAndTypes/plugins/FooterPlugin'
@@ -28,59 +28,75 @@ export const FooterPlugin = () => {
     >
       {/* Centers content horizontally and restricts the width */}
       <Container maxWidth="xl" sx={{ py: 1 }}>
-        <Grid container direction="row" columnSpacing={6} sx={{ alignItems: 'center', justifyContent: 'center' }}>
+        {/* Wraps rather than overflows: where one row is not enough, the copyright and each link
+            group take a row of their own instead of being squeezed into one. */}
+        <Box
+          sx={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            alignItems: 'center',
+            justifyContent: 'center',
+            columnGap: { xs: 2, lg: 6 },
+            rowGap: 1,
+          }}
+        >
           {/* Copyright */}
           {footerPluginConfig.copyright && (
-            <Grid key={'Copyright'} data-testid={testIDs.plugins.footer.copyright}>
-              <Typography variant="body2" color="text.secondary">
-                © {new Date().getFullYear()} {footerPluginConfig.copyright}
-              </Typography>
-            </Grid>
+            <Typography data-testid={testIDs.plugins.footer.copyright} variant="body2" color="text.secondary">
+              © {new Date().getFullYear()} {footerPluginConfig.copyright}
+            </Typography>
           )}
           {/* Link groups */}
-          {footerPluginConfig.links.map((linkGroup) => {
+          {footerPluginConfig.links.map((linkGroup, index) => {
             return (
-              <div key={linkGroup.title}>
-                <Divider orientation="vertical" flexItem sx={{ display: { md: 'none', lg: 'block' } }} />
-                <Grid>
-                  <Stack
-                    data-testid={testIDs.plugins.footer.linkGroup.main}
-                    direction="row"
-                    style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}
+              <Fragment key={linkGroup.title}>
+                {/* A separator only where everything fits on one row: on a wrapped row it would end
+                    up at the end of a line rather than between two groups. A direct child of the
+                    flex row, because that is what gives `flexItem` a height to stretch to. */}
+                {(index > 0 || footerPluginConfig.copyright) && (
+                  <Divider orientation="vertical" flexItem sx={{ display: { xs: 'none', lg: 'block' } }} />
+                )}
+                <Box
+                  data-testid={testIDs.plugins.footer.linkGroup.main}
+                  sx={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: 1,
+                  }}
+                >
+                  {/* Link group title */}
+                  <Typography
+                    data-testid={testIDs.plugins.footer.linkGroup.title}
+                    variant="body2"
+                    color="text.secondary"
                   >
-                    {/* Link group title */}
-                    <Typography
-                      data-testid={testIDs.plugins.footer.linkGroup.title}
-                      variant="body2"
-                      color="text.secondary"
-                      sx={{ mr: 2 }}
-                    >
-                      {linkGroup.title}
-                    </Typography>
-                    {/* Link group links */}
-                    {linkGroup.links.map((link) => {
-                      const LinkIcon = iconMap[link.icon]
-                      return (
-                        <Button
-                          data-testid={testIDs.plugins.footer.linkGroup.link.main}
-                          key={link.href}
-                          sx={{ textTransform: 'none', mr: 1 }}
-                          component={Link}
-                          href={link.href}
-                          target={link.target}
-                          startIcon={<LinkIcon />}
-                          variant="outlined"
-                        >
-                          {link.title}
-                        </Button>
-                      )
-                    })}
-                  </Stack>
-                </Grid>
-              </div>
+                    {linkGroup.title}
+                  </Typography>
+                  {/* Link group links */}
+                  {linkGroup.links.map((link) => {
+                    const LinkIcon = iconMap[link.icon]
+                    return (
+                      <Button
+                        data-testid={testIDs.plugins.footer.linkGroup.link.main}
+                        key={link.href}
+                        sx={{ textTransform: 'none' }}
+                        component={Link}
+                        href={link.href}
+                        target={link.target}
+                        startIcon={<LinkIcon />}
+                        variant="outlined"
+                      >
+                        {link.title}
+                      </Button>
+                    )
+                  })}
+                </Box>
+              </Fragment>
             )
           })}
-        </Grid>
+        </Box>
       </Container>
     </Paper>
   )


### PR DESCRIPTION
## Why

The pages were built for one viewport and read as an accident on any other: content stopped at 1200px on a 2500px screen, project cards sat two to a row on a phone with their titles cut off, and the logo was given a twelfth of the app bar's width.

Two of the defects were the same mistake in two places — a wrapper element between a `Grid` container and its item, which breaks the parent/child contract MUI's grid relies on. The footer's separators therefore had no height and **never rendered at all**, and the version overview's `latest` badge sat beside its chip rather than on it.

## What changed

| Area | Before | After |
| --- | --- | --- |
| Landing page, version index | `Container` capped at `lg` (1200px) | `maxWidth="xl"`, the same container the footer already used, so page and footer content share one edge |
| Project cards | `xs: 6` — two per row on a phone, titles cut off | `xs: 12, sm: 6, md: 4, lg: 3`; `minHeight` only from `sm` up, since a single column has no row to match |
| Version cards | `size={6}` fixed | `xs: 12, md: 6`, and `height: '100%'` so the cards of a row end on the same line |
| App bar | three fixed twelfth-based columns | outer groups take their content width, search bar takes the rest — no breakpoint guesses a split |
| Content padding | `pt: '64px'` hardcoded | measured from the app bar, which is 56px below `sm` and 48px in landscape |
| Footer | `Grid` container → `<div>` → `Grid` item; separators invisible | wrapping flex row, separators render, `columnGap` per breakpoint |
| Version chips | nested `Grid` + `mb: 1` per chip, `Badge` around the grid item | wrapping flex row with `columnGap`/`rowGap`, badge on the chip |

Typography on the landing page comes from the theme's own variants again: the hardcoded `fontSize: 14` on the card titles is gone, category headings are `h5`, card titles `h6`.

## Verification

- `tsc`, biome and prettier clean; Vitest 87/87.
- Playwright 93/94. The one failure, `testOramaPlugin` › _Active orama plugin works as expected_, fails identically on unmodified `main` and is untouched here.
- No test was added or changed. The existing invariant in `tests/ui/testScrollBehavior.spec.ts` — content padding equals app bar height — now holds at every breakpoint rather than only where the constant happened to match.
- Screenshots checked at 2560, 1615, 1280 and 390px, and `scrollWidth` compared against `clientWidth` at each: no horizontal overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)